### PR TITLE
Implement traffic command

### DIFF
--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -1,0 +1,227 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/api/v1/client/policy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var trafficOptions struct {
+	selector string
+}
+
+func init() {
+	trafficCmd.Flags().StringVarP(&trafficOptions.selector, "selector", "l", "", "specify label constraints")
+	rootCmd.AddCommand(trafficCmd)
+}
+
+var trafficCmd = &cobra.Command{
+	Use:   "traffic",
+	Short: "Show traffic amount of selected pods",
+	Long:  `Show traffic amount of selected pods`,
+
+	Args: cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return runTraffic(context.Background(), cmd.OutOrStdout(), "")
+		} else {
+			return runTraffic(context.Background(), cmd.OutOrStdout(), args[0])
+		}
+	},
+	ValidArgsFunction: completePods,
+}
+
+type trafficKey struct {
+	Direction        string `json:"direction"`
+	Identity         int    `json:"identity"`
+	Namespace        string `json:"namespace"`
+	CIDR             string `json:"cidr"`
+	WildcardProtocol bool   `json:"wildcard_protocol"`
+	WildcardPort     bool   `json:"wildcard_port"`
+	Protocol         int    `json:"protocol"`
+	Port             int    `json:"port"`
+}
+
+type trafficValue struct {
+	Example string `json:"example"`
+	Bytes   int    `json:"bytes"`
+	Packets int    `json:"packets"`
+}
+
+type trafficEntry struct {
+	trafficKey
+	trafficValue
+}
+
+func lessTrafficEntry(x, y *trafficEntry) bool {
+	ret := strings.Compare(x.Direction, y.Direction)
+	if ret == 0 {
+		ret = strings.Compare(x.Namespace, y.Namespace)
+	}
+	if ret == 0 {
+		ret = x.Identity - y.Identity
+	}
+	if ret == 0 {
+		ret = strings.Compare(x.CIDR, y.CIDR)
+	}
+	return ret < 0
+}
+
+func runTraffic(ctx context.Context, w io.Writer, name string) error {
+	if (name != "") && (trafficOptions.selector != "") {
+		return errors.New("pod name and selector should not be specified at once")
+	}
+
+	clientset, dynamicClient, err := createK8sClients()
+	if err != nil {
+		return err
+	}
+
+	var pods []string
+	if name != "" {
+		pods = []string{name}
+	} else {
+		resources, err := clientset.CoreV1().Pods(rootOptions.namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: trafficOptions.selector,
+		})
+		if err != nil {
+			return err
+		}
+		for _, r := range resources.Items {
+			pods = append(pods, r.Name)
+		}
+	}
+
+	ids, err := getIdentityResourceMap(ctx, dynamicClient)
+	if err != nil {
+		return err
+	}
+
+	idEndpoints, err := getIdentityEndpoints(ctx, dynamicClient)
+	if err != nil {
+		return err
+	}
+
+	traffic := make(map[trafficKey]*trafficValue)
+	for _, name := range pods {
+		client, err := createCiliumClient(ctx, clientset, rootOptions.namespace, name)
+		if err != nil {
+			return fmt.Errorf("failed to create Cilium client: %w", err)
+		}
+
+		policies, err := queryPolicyMap(ctx, clientset, dynamicClient, rootOptions.namespace, name)
+		if err != nil {
+			return err
+		}
+
+		for _, p := range policies {
+			if (p.Packets == 0) || p.IsDenyRule() {
+				continue
+			}
+
+			var k trafficKey
+			if p.IsEgressRule() {
+				k.Direction = directionEgress
+			} else {
+				k.Direction = directionIngress
+			}
+
+			k.Namespace = "-"
+			if id, ok := ids[p.Key.Identity]; ok {
+				ns, ok, err := unstructured.NestedString(id.Object, "security-labels", "k8s:io.kubernetes.pod.namespace")
+				if err != nil {
+					return err
+				}
+				if ok {
+					k.Namespace = ns
+				}
+			}
+
+			k.Identity = p.Key.Identity
+			example := "-"
+			if v, ok := idEndpoints[p.Key.Identity]; ok {
+				i := rand.IntN(len(v))
+				example = v[i].GetName()
+			} else {
+				idObj := identity.NumericIdentity(p.Key.Identity)
+				if idObj.IsReservedIdentity() {
+					example = "reserved:" + idObj.String()
+				} else if idObj.HasLocalScope() {
+					// If the identity is in the local scope, it is only valid on the reporting node.
+					params := policy.GetIdentityIDParams{
+						Context: ctx,
+						ID:      strconv.FormatInt(int64(p.Key.Identity), 10),
+					}
+					response, err := client.Policy.GetIdentityID(&params)
+					if err != nil {
+						return fmt.Errorf("failed to get identity: %w", err)
+					}
+					if slices.Contains(response.Payload.Labels, "reserved:world") {
+						lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+						cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
+						if len(cidrModel) == 1 {
+							// Cilium allocates different identity for a CIDR between nodes, so we cannot use it as a key.
+							// Instead, npv shows traffic as belonging to the world identity and differentiate it using CIDR.
+							k.Identity = int(identity.ReservedIdentityWorld)
+							k.CIDR = strings.Split(cidrModel[0], ":")[1]
+							example = cidrModel[0]
+						}
+					}
+				}
+			}
+
+			k.WildcardProtocol = p.IsWildcardProtocol()
+			k.WildcardPort = p.IsWildcardPort()
+			k.Protocol = p.Key.Protocol
+			k.Port = p.Key.Port()
+
+			if _, ok := traffic[k]; ok {
+				traffic[k].Bytes += p.Bytes
+				traffic[k].Packets += p.Packets
+			} else {
+				traffic[k] = &trafficValue{
+					Example: example,
+					Bytes:   p.Bytes,
+					Packets: p.Packets,
+				}
+			}
+		}
+	}
+
+	arr := make([]trafficEntry, 0)
+	for k, v := range traffic {
+		arr = append(arr, trafficEntry{k, *v})
+	}
+	sort.Slice(arr, func(i, j int) bool { return lessTrafficEntry(&arr[i], &arr[j]) })
+
+	header := []string{"DIRECTION", "IDENTITY", "NAMESPACE", "EXAMPLE", "PROTOCOL", "PORT", "BYTES", "PACKETS"}
+	return writeSimpleOrJson(w, arr, header, len(arr), func(index int) []any {
+		p := arr[index]
+		var protocol, port string
+		if p.WildcardProtocol {
+			protocol = "ANY"
+		} else {
+			protocol = u8proto.U8proto(p.Protocol).String()
+		}
+		if p.WildcardPort {
+			port = "ANY"
+		} else {
+			port = strconv.Itoa(p.Port)
+		}
+		return []any{p.Direction, p.Identity, p.Namespace, p.Example, protocol, port, p.Bytes, p.Packets}
+	})
+}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -78,6 +78,7 @@ install-test-pod:
 
 	# Cilium-agents on different nodes may simultaneously create multiple CiliumIdentities for a same set of labels.
 	# To enforce the following test deployment to use a same CiliumIdentity, we first create it with replicas=1 and then upscale.
+	$(MAKE) --no-print-directory DEPLOYMENT_REPLICAS=2 run-ubuntu-pod-self
 	$(MAKE) --no-print-directory DEPLOYMENT_REPLICAS=2 run-test-pod-l3-ingress-explicit-allow-all
 	$(MAKE) --no-print-directory wait-for-workloads
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -41,6 +41,16 @@ start:
 run-test-pod-%:
 	@# https://github.com/orgs/aquaproj/discussions/2964
 	@echo Hello | yq > /dev/null
+	cat testdata/template/testhttpd.yaml | \
+		yq '.metadata.name = "$*"' | \
+		yq '.spec.replicas = $(DEPLOYMENT_REPLICAS)' | \
+		yq '.spec.selector.matchLabels = {"test": "$*"}' | \
+		yq '.spec.template.metadata.labels = {"test": "$*", "group": "test"}' | \
+		kubectl apply -f -
+
+run-ubuntu-pod-%:
+	@# https://github.com/orgs/aquaproj/discussions/2964
+	@echo Hello | yq > /dev/null
 	cat testdata/template/ubuntu.yaml | \
 		yq '.metadata.name = "$*"' | \
 		yq '.spec.replicas = $(DEPLOYMENT_REPLICAS)' | \
@@ -50,7 +60,7 @@ run-test-pod-%:
 
 .PHONY: install-test-pod
 install-test-pod:
-	$(MAKE) --no-print-directory run-test-pod-self
+	$(MAKE) --no-print-directory run-ubuntu-pod-self
 	$(MAKE) --no-print-directory run-test-pod-l3-ingress-explicit-allow-all
 	$(MAKE) --no-print-directory run-test-pod-l3-ingress-implicit-deny-all
 	$(MAKE) --no-print-directory run-test-pod-l3-ingress-explicit-deny-all

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -23,7 +23,7 @@ Allow,Egress,l3-ingress-implicit-deny-all,true,true,0,0
 Allow,Egress,l4-ingress-explicit-allow-any,false,false,6,53
 Allow,Egress,l4-ingress-explicit-allow-any,false,false,17,53
 Allow,Egress,l4-ingress-explicit-allow-any,false,false,132,53
-Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8080
+Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,6,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,17,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,132,53
@@ -36,7 +36,7 @@ Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
 Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
 Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
 Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
-Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8080`,
+Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
 		},
 		{
 			Selector: "test=l3-ingress-explicit-allow-all",
@@ -70,7 +70,7 @@ Allow,Ingress,self,false,false,132,53`,
 		{
 			Selector: "test=l4-ingress-explicit-allow-tcp",
 			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,self,false,false,6,8080`,
+Allow,Ingress,self,false,false,6,8000`,
 		},
 		{
 			Selector: "test=l4-ingress-explicit-deny-any",
@@ -94,9 +94,9 @@ Deny,Ingress,self,false,false,17,161`,
 		},
 		{
 			Selector: "test=l4-ingress-all-allow-tcp",
-			Expected: `Allow,Ingress,reserved:host,false,false,6,8080
+			Expected: `Allow,Ingress,reserved:host,false,false,6,8000
 Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,reserved:unknown,false,false,6,8080`,
+Allow,Ingress,reserved:unknown,false,false,6,8000`,
 		},
 	}
 

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -14,7 +14,10 @@ func testInspect() {
 	}{
 		{
 			Selector: "test=self",
-			Expected: `Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
+			Expected: `Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,132,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
 Allow,Egress,l3-ingress-explicit-allow-all,true,true,0,0

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -165,7 +165,7 @@ spec:
         k8s:test: l4-ingress-explicit-allow-tcp
     toPorts:
     - ports:
-      - port: "8080"
+      - port: "8000"
         protocol: TCP
   - toEndpoints:
     - matchLabels:
@@ -197,7 +197,7 @@ spec:
         k8s:test: l4-egress-explicit-deny-tcp
     toPorts:
     - ports:
-      - port: "8080"
+      - port: "8000"
         protocol: TCP
   - toCIDR:
     - 8.8.4.4/32

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -181,6 +181,7 @@ spec:
       - port: "161"
         protocol: UDP
   - toCIDR:
+    - 1.1.1.1/32
     - 8.8.8.8/32
     toPorts:
     - ports:

--- a/e2e/manifest_test.go
+++ b/e2e/manifest_test.go
@@ -131,6 +131,7 @@ spec:
 
 func testManifestRange() {
 	expected := `From,test,self
+From,test,self
 To,test,l3-ingress-explicit-allow-all
 To,test,l3-ingress-explicit-allow-all`
 

--- a/e2e/reach_test.go
+++ b/e2e/reach_test.go
@@ -45,8 +45,8 @@ test,self,Egress,Allow,false,false,132,53`,
 		},
 		{
 			Selector: "test=l4-ingress-explicit-allow-tcp",
-			Expected: `test,l4-ingress-explicit-allow-tcp,Ingress,Allow,false,false,6,8080
-test,self,Egress,Allow,false,false,6,8080`,
+			Expected: `test,l4-ingress-explicit-allow-tcp,Ingress,Allow,false,false,6,8000
+test,self,Egress,Allow,false,false,6,8000`,
 		},
 		{
 			Selector: "test=l4-ingress-explicit-deny-any",
@@ -70,11 +70,11 @@ test,self,Egress,Deny,false,false,132,53`,
 		},
 		{
 			Selector: "test=l4-egress-explicit-deny-tcp",
-			Expected: `test,self,Egress,Deny,false,false,6,8080`,
+			Expected: `test,self,Egress,Deny,false,false,6,8000`,
 		},
 		{
 			Selector: "test=l4-ingress-all-allow-tcp",
-			Expected: `test,l4-ingress-all-allow-tcp,Ingress,Allow,false,false,6,8080`,
+			Expected: `test,l4-ingress-all-allow-tcp,Ingress,Allow,false,false,6,8000`,
 		},
 	}
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -33,4 +33,5 @@ func runTest() {
 	Context("manifest-generate", testManifestGenerate)
 	Context("manifest-range", testManifestRange)
 	Context("reach", testReach)
+	Context("traffic", testTraffic)
 }

--- a/e2e/summary_test.go
+++ b/e2e/summary_test.go
@@ -21,8 +21,8 @@ l4-ingress-explicit-allow-any,4,0,0,0
 l4-ingress-explicit-allow-tcp,2,0,0,0
 l4-ingress-explicit-deny-any,1,3,0,0
 l4-ingress-explicit-deny-udp,1,1,0,0
-self,1,0,14,8
-self,1,0,14,8`
+self,1,0,17,8
+self,1,0,17,8`
 
 	It("should show summary", func() {
 		result := runViewerSafe(Default, nil, "summary", "-o=json", "-n=test")

--- a/e2e/summary_test.go
+++ b/e2e/summary_test.go
@@ -21,6 +21,7 @@ l4-ingress-explicit-allow-any,4,0,0,0
 l4-ingress-explicit-allow-tcp,2,0,0,0
 l4-ingress-explicit-deny-any,1,3,0,0
 l4-ingress-explicit-deny-udp,1,1,0,0
+self,1,0,14,8
 self,1,0,14,8`
 
 	It("should show summary", func() {

--- a/e2e/testdata/onboard
+++ b/e2e/testdata/onboard
@@ -3,6 +3,7 @@
 if ! grep boarded /root/.bashrc > /dev/null 2>&1; then
     echo '. /usr/share/bash-completion/bash_completion' >> /root/.bashrc
     echo 'export PATH=${PATH}:/tmp' >> /root/.bashrc
+    echo '. <(kubectl completion bash)' >> /root/.bashrc
     echo '. <(npv completion bash)' >> /root/.bashrc
     echo '# boarded' >> /root/.bashrc
 fi

--- a/e2e/testdata/policy/README.md
+++ b/e2e/testdata/policy/README.md
@@ -15,5 +15,6 @@
 | l4-egress-explicit-deny-any | deny (L4) | - |
 | l4-egress-explicit-deny-tcp | deny (L4) | - |
 | l4-ingress-all-allow-tcp | - | allow (L4-only) |
+| 1.1.1.1 (Cloudflare DNS) | allow (L4) | - |
 | 8.8.8.8 (Google Public DNS) | allow (L4) | - |
 | 8.8.4.4 (Google Public DNS)  | deny (L4) | - |

--- a/e2e/testdata/policy/l4.yaml
+++ b/e2e/testdata/policy/l4.yaml
@@ -35,7 +35,8 @@ spec:
             - port: "161" # SNMP (UDP)
               protocol: UDP
     - toCIDR:
-        - 8.8.8.8/32
+        - 1.1.1.1/32 # Cloudflare DNS
+        - 8.8.8.8/32 # Google Public DNS
       toPorts:
         - ports:
             - port: "53"
@@ -54,7 +55,7 @@ spec:
             - port: "8000"
               protocol: TCP
     - toCIDR:
-        - 8.8.4.4/32
+        - 8.8.4.4/32 # Google Public DNS
       toPorts:
         - ports:
             - port: "53"

--- a/e2e/testdata/policy/l4.yaml
+++ b/e2e/testdata/policy/l4.yaml
@@ -19,7 +19,7 @@ spec:
             k8s:test: l4-ingress-explicit-allow-tcp
       toPorts:
         - ports:
-            - port: "8080"
+            - port: "8000"
               protocol: TCP
     - toEndpoints:
         - matchLabels:
@@ -51,7 +51,7 @@ spec:
             k8s:test: l4-egress-explicit-deny-tcp
       toPorts:
         - ports:
-            - port: "8080"
+            - port: "8000"
               protocol: TCP
     - toCIDR:
         - 8.8.4.4/32
@@ -91,7 +91,7 @@ spec:
             k8s:test: self
       toPorts:
         - ports:
-            - port: "8080"
+            - port: "8000"
               protocol: TCP
 ---
 apiVersion: cilium.io/v2
@@ -141,5 +141,5 @@ spec:
   ingress:
     - toPorts:
         - ports:
-            - port: "8080"
+            - port: "8000"
               protocol: TCP

--- a/e2e/testdata/template/testhttpd.yaml
+++ b/e2e/testdata/template/testhttpd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: test
+  name: testhttpd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testhttpd
+  template:
+    metadata:
+      labels:
+        app: testhttpd
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: testhttpd
+          image: ghcr.io/cybozu/testhttpd:0

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func formatTrafficResult(result []byte, amount bool) string {
+	// remove hash suffix from pod names
+	result = jqSafe(Default, result, "-r", `[.[] | .example = (.example | split("-") | .[0:5] | join("-"))]`)
+	result = jqSafe(Default, result, "-r", `[.[] | .example = (.example | if startswith("self") then "self" else . end)]`)
+	result = jqSafe(Default, result, "-r", `sort_by(.direction, .cidr, .example, .wildcard_protocol, .wildcard_port, .protocol, .port)`)
+	if amount {
+		result = jqSafe(Default, result, "-r", `.[] | [.example, .bytes] | @csv`)
+	} else {
+		result = jqSafe(Default, result, "-r", `.[] | [.direction, .cidr, .example, .wildcard_protocol, .wildcard_port, .protocol, .port] | @csv`)
+	}
+	return strings.Replace(string(result), `"`, "", -1)
+}
+
+func readTraffic(result string) map[string]int {
+	ret := make(map[string]int)
+
+	scanner := bufio.NewScanner(strings.NewReader(result))
+	for scanner.Scan() {
+		line := scanner.Text()
+		kv := strings.Split(line, ",")
+		Expect(kv).To(HaveLen(2))
+
+		v, err := strconv.Atoi(kv[1])
+		Expect(err).NotTo(HaveOccurred())
+
+		ret[kv[0]] += v
+	}
+	return ret
+}
+
+func testTraffic() {
+	It("should show all active routes", func() {
+		data := kubectlSafe(Default, nil, "get", "pod", "-n=test", "-l=test=self", "-o=jsonpath={.items[*].metadata.name}")
+		selfNames := strings.Fields(string(data))
+		l3PodName := onePodByLabelSelector(Default, "test", "test=l3-ingress-explicit-allow-all")
+		l4PodName := onePodByLabelSelector(Default, "test", "test=l4-ingress-explicit-allow-tcp")
+		l3PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l3PodName, "-o=jsonpath={.status.podIP}"))
+		l4PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l4PodName, "-o=jsonpath={.status.podIP}"))
+
+		kubectlSafe(Default, nil, "exec", "-n=test", selfNames[0], "--", "dig", "@1.1.1.1", "google.com")
+		kubectlSafe(Default, nil, "exec", "-n=test", selfNames[1], "--", "dig", "@8.8.8.8", "google.com")
+		for _, p := range selfNames {
+			kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l3PodIP))
+			kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l4PodIP))
+		}
+
+		cases := []struct {
+			Selector string
+			Expected string
+		}{
+			{
+				Selector: l3PodName,
+				Expected: `Ingress,,self,true,true,0,0`,
+			},
+			{
+				Selector: l4PodName,
+				Expected: `Ingress,,self,false,false,6,8000`,
+			},
+			{
+				Selector: selfNames[0],
+				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
+Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
+Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53`,
+			},
+			{
+				Selector: selfNames[1],
+				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
+Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
+Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
+			},
+			{
+				Selector: "-l=test=self",
+				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
+Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
+Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53
+Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
+			},
+		}
+		for _, c := range cases {
+			result := runViewerSafe(Default, nil, "traffic", "-o=json", "-n=test", c.Selector)
+			resultString := formatTrafficResult(result, false)
+			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nactual: %s\nexpected: %s", c.Selector, resultString, c.Expected)
+		}
+
+		By("checking npv traffic -l shows combined traffic amount")
+		result := runViewerSafe(Default, nil, "traffic", "-o=json", "-n=test", selfNames[0])
+		result1 := formatTrafficResult(result, true)
+
+		result = runViewerSafe(Default, nil, "traffic", "-o=json", "-n=test", selfNames[1])
+		result2 := formatTrafficResult(result, true)
+		amount12 := readTraffic(result1 + "\n" + result2)
+
+		result = runViewerSafe(Default, nil, "traffic", "-o=json", "-n=test", "-l=test=self")
+		result3 := formatTrafficResult(result, true)
+		amount3 := readTraffic(result3)
+		Expect(amount12).To(Equal(amount3))
+	})
+}


### PR DESCRIPTION
This PR implements `npv traffic` command.

## Usage
- `npv traffic -n [NAMESPACE]`
- `npv traffic -n [NAMESPACE] [POD]`
- `npv traffic -n [NAMESPACE] -l [SELECTOR]`

When multiple pods are selected, it shows the combined traffic amount.

## Example Result
```
$ npv traffic -n test -l test=self
DIRECTION IDENTITY NAMESPACE EXAMPLE                                        PROTOCOL PORT BYTES PACKETS
Egress    2        -         cidr:1.1.1.1/32                                UDP      53   558   6
Egress    2        -         cidr:8.8.8.8/32                                UDP      53   558   6
Egress    22197    test      l4-ingress-explicit-allow-tcp-674bf84548-vbk7k TCP      8000 5820  72
Egress    23557    test      l3-ingress-explicit-allow-all-854c9bb96c-96nqs ANY      ANY  5808  72
```

## Implementation
1. `npv traffic` computes the list of pods, for which the traffic amount should be displayed
2. It asks cilium-agent on each node through cilium-agent-proxy to query BPF policy map, along with traffic amount for each route (similar to `npv inspect`)
3. It selects allowed and active (traffic > 0) routes
4. Combine the traffic amount for pods and display the result

## CI update
Overview: [e2e/testdata/policy/README.md](https://github.com/cybozu-go/network-policy-viewer/blob/main/e2e/testdata/policy/README.md)

This PR:
- raises self pod from one to two, to check `npv traffic` shows combined traffic amount
- changes test pods from ubuntu to testhttpd, to make real traffic
- allows self pods to reach `1.1.1.1` (Cloudflare DNS)