### PR TITLE
traffic: skip host-network and not-running pods

### DIFF
--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -79,8 +79,8 @@ func getPodIdentity(ctx context.Context, d *dynamic.DynamicClient, namespace, na
 	return identity, nil
 }
 
-func listRelevantPods(ctx context.Context, c *kubernetes.Clientset, namespace string) ([]corev1.Pod, error) {
-	pods, err := c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+func listRelevantPods(ctx context.Context, c *kubernetes.Clientset, namespace string, opts metav1.ListOptions) ([]corev1.Pod, error) {
+	pods, err := c.CoreV1().Pods(namespace).List(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/npv/app/helper_completion.go
+++ b/cmd/npv/app/helper_completion.go
@@ -37,7 +37,7 @@ func completePods(cmd *cobra.Command, args []string, toComplete string) (ret []s
 		return
 	}
 
-	pods, err := listRelevantPods(context.Background(), clientset, rootOptions.namespace)
+	pods, err := listRelevantPods(context.Background(), clientset, rootOptions.namespace, metav1.ListOptions{})
 	if err != nil {
 		return
 	}
@@ -60,7 +60,7 @@ func completeNamespacePods(cmd *cobra.Command, args []string, toComplete string)
 	li := strings.Split(toComplete, "/")
 	switch len(li) {
 	case 2: // namespace already filled
-		pods, err := listRelevantPods(context.Background(), clientset, li[0])
+		pods, err := listRelevantPods(context.Background(), clientset, li[0], metav1.ListOptions{})
 		if err != nil {
 			return
 		}

--- a/cmd/npv/app/summary.go
+++ b/cmd/npv/app/summary.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -48,7 +49,7 @@ func runSummary(ctx context.Context, w io.Writer) error {
 	}
 
 	summary := make([]summaryEntry, 0)
-	pods, err := listRelevantPods(ctx, clientset, rootOptions.namespace)
+	pods, err := listRelevantPods(ctx, clientset, rootOptions.namespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -95,13 +95,13 @@ func runTraffic(ctx context.Context, w io.Writer, name string) error {
 	if name != "" {
 		pods = []string{name}
 	} else {
-		resources, err := clientset.CoreV1().Pods(rootOptions.namespace).List(ctx, metav1.ListOptions{
+		resources, err := listRelevantPods(ctx, clientset, rootOptions.namespace, metav1.ListOptions{
 			LabelSelector: trafficOptions.selector,
 		})
 		if err != nil {
 			return err
 		}
-		for _, r := range resources.Items {
+		for _, r := range resources {
 			pods = append(pods, r.Name)
 		}
 	}


### PR DESCRIPTION
Fix `npv traffic` to not listing host-network and not-running pods.

ref:
- https://github.com/cybozu-go/network-policy-viewer/pull/14

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
