### PR TITLE
Add --with-cidrs option to inspect and traffic commands

### DIFF
--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -17,6 +17,7 @@ import (
 )
 
 func init() {
+	addWithCIDROptions(inspectCmd)
 	rootCmd.AddCommand(inspectCmd)
 }
 
@@ -49,6 +50,10 @@ type inspectEntry struct {
 }
 
 func runInspect(ctx context.Context, w io.Writer, name string) error {
+	if err := parseWithCIDROptions(); err != nil {
+		return err
+	}
+
 	clientset, dynamicClient, err := createK8sClients()
 	if err != nil {
 		return err
@@ -61,6 +66,9 @@ func runInspect(ctx context.Context, w io.Writer, name string) error {
 
 	policies, err := queryPolicyMap(ctx, clientset, dynamicClient, rootOptions.namespace, name)
 	if err != nil {
+		return err
+	}
+	if policies, err = filterPolicyMap(ctx, client, policies, commonOptions.withCIDRFilter); err != nil {
 		return err
 	}
 

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func addWithCIDROptions(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&commonOptions.withCIDR, "with-cidr", "", "show rules for CIDR")
+	cmd.Flags().StringVar(&commonOptions.withCIDR, "with-cidrs", "", "show rules for CIDRs")
 	cmd.Flags().BoolVar(&commonOptions.withPrivateCIDRs, "with-private-cidrs", false, "show rules for private CIDRs")
 	cmd.Flags().BoolVar(&commonOptions.withPublicCIDRs, "with-public-cidrs", false, "show rules for public CIDRs")
 }
@@ -73,11 +73,11 @@ func parseWithCIDROptions() error {
 	case 1:
 		incl, excl, err := parseCIDRFlag(expr)
 		if err != nil {
-			return fmt.Errorf("failed to parse --with-cidr: %w", err)
+			return fmt.Errorf("failed to parse --with-cidrs: %w", err)
 		}
 		commonOptions.withCIDRFilter = makeCIDRFilter(true, true, incl, excl)
 	default:
-		return errors.New("one of --with-cidr, --with-private-cidrs, --with-public-cidrs can be specified")
+		return errors.New("one of --with-cidrs, --with-private-cidrs, --with-public-cidrs can be specified")
 	}
 	return nil
 }

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -24,6 +24,7 @@ var trafficOptions struct {
 
 func init() {
 	trafficCmd.Flags().StringVarP(&trafficOptions.selector, "selector", "l", "", "specify label constraints")
+	addWithCIDROptions(trafficCmd)
 	rootCmd.AddCommand(trafficCmd)
 }
 
@@ -80,6 +81,10 @@ func lessTrafficEntry(x, y *trafficEntry) bool {
 }
 
 func runTraffic(ctx context.Context, w io.Writer, name string) error {
+	if err := parseWithCIDROptions(); err != nil {
+		return err
+	}
+
 	clientset, dynamicClient, err := createK8sClients()
 	if err != nil {
 		return err
@@ -109,6 +114,9 @@ func runTraffic(ctx context.Context, w io.Writer, name string) error {
 
 		policies, err := queryPolicyMap(ctx, clientset, dynamicClient, p.Namespace, p.Name)
 		if err != nil {
+			return err
+		}
+		if policies, err = filterPolicyMap(ctx, client, policies, commonOptions.withCIDRFilter); err != nil {
 			return err
 		}
 

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -46,7 +46,7 @@ Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,
 		},
 		{
 			Selector:  "test=self",
-			ExtraArgs: []string{"--with-cidr=8.8.0.0/16"},
+			ExtraArgs: []string{"--with-cidrs=8.8.0.0/16"},
 			Expected: `Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
@@ -56,24 +56,24 @@ Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
-			ExtraArgs: []string{"--with-cidr=8.8.0.0/16,!8.8.8.8/32"},
+			ExtraArgs: []string{"--with-cidrs=8.8.0.0/16,!8.8.8.8/32"},
 			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
 Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
 Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
-			ExtraArgs: []string{"--with-cidr=10.100.0.0/12,!10.100.0.0/16"},
+			ExtraArgs: []string{"--with-cidrs=10.100.0.0/12,!10.100.0.0/16"},
 			Expected:  ``,
 		},
 		{
 			Selector:  "test=self",
-			ExtraArgs: []string{"--with-cidr=10.100.0.0/12,!10.100.0.0/20"},
+			ExtraArgs: []string{"--with-cidrs=10.100.0.0/12,!10.100.0.0/20"},
 			Expected:  `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0`,
 		},
 		{
 			Selector:  "test=self",
-			ExtraArgs: []string{"--with-cidr=10.100.0.0/16,!10.100.0.0/16"},
+			ExtraArgs: []string{"--with-cidrs=10.100.0.0/16,!10.100.0.0/16"},
 			Expected:  ``,
 		},
 		{

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -9,8 +9,9 @@ import (
 
 func testInspect() {
 	cases := []struct {
-		Selector string
-		Expected string
+		Selector  string
+		ExtraArgs []string
+		Expected  string
 	}{
 		{
 			Selector: "test=self",
@@ -31,6 +32,7 @@ Allow,Egress,l4-ingress-explicit-deny-any,false,false,6,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,17,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,132,53
 Allow,Egress,l4-ingress-explicit-deny-udp,false,false,17,161
+Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
 Allow,Ingress,reserved:host,true,true,0,0
 Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
 Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
@@ -39,7 +41,44 @@ Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
 Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
 Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
 Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
-Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
+Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000
+Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidr=8.8.0.0/16"},
+			Expected: `Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidr=8.8.0.0/16,!8.8.8.8/32"},
+			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-private-cidrs"},
+			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
+Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-public-cidrs"},
+			Expected: `Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,132,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		},
 		{
 			Selector: "test=l3-ingress-explicit-allow-all",
@@ -106,7 +145,8 @@ Allow,Ingress,reserved:unknown,false,false,6,8000`,
 	It("should inspect policy configuration", func() {
 		for _, c := range cases {
 			podName := onePodByLabelSelector(Default, "test", c.Selector)
-			result := runViewerSafe(Default, nil, "inspect", "-o=json", "-n=test", podName)
+			args := append([]string{"inspect", "-o=json", "-n=test", podName}, c.ExtraArgs...)
+			result := runViewerSafe(Default, nil, args...)
 			// remove hash suffix from pod names
 			result = jqSafe(Default, result, "-r", `[.[] | .example = (.example | split("-") | .[0:5] | join("-"))]`)
 			result = jqSafe(Default, result, "-r", `[.[] | .example = (.example | if startswith("self") then "self" else . end)]`)
@@ -114,7 +154,7 @@ Allow,Ingress,reserved:unknown,false,false,6,8000`,
 			result = jqSafe(Default, result, "-r", `sort_by(.policy, .direction, .example, .wildcard_protocol, .wildcard_port, .protocol, .port)`)
 			result = jqSafe(Default, result, "-r", `.[] | [.policy, .direction, .example, .wildcard_protocol, .wildcard_port, .protocol, .port] | @csv`)
 			resultString := strings.Replace(string(result), `"`, "", -1)
-			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nactual: %s\nexpected: %s", c.Selector, resultString, c.Expected)
+			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nargs: %v\nactual: %s\nexpected: %s", c.Selector, c.ExtraArgs, resultString, c.Expected)
 		}
 	})
 }

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -63,6 +63,21 @@ Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidr=10.100.0.0/12,!10.100.0.0/16"},
+			Expected:  ``,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidr=10.100.0.0/12,!10.100.0.0/20"},
+			Expected:  `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidr=10.100.0.0/16,!10.100.0.0/16"},
+			Expected:  ``,
+		},
+		{
+			Selector:  "test=self",
 			ExtraArgs: []string{"--with-private-cidrs"},
 			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
 Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,

--- a/e2e/summary_test.go
+++ b/e2e/summary_test.go
@@ -21,8 +21,8 @@ l4-ingress-explicit-allow-any,4,0,0,0
 l4-ingress-explicit-allow-tcp,2,0,0,0
 l4-ingress-explicit-deny-any,1,3,0,0
 l4-ingress-explicit-deny-udp,1,1,0,0
-self,1,0,17,8
-self,1,0,17,8`
+self,2,1,17,8
+self,2,1,17,8`
 
 	It("should show summary", func() {
 		result := runViewerSafe(Default, nil, "summary", "-o=json", "-n=test")

--- a/e2e/testdata/policy/README.md
+++ b/e2e/testdata/policy/README.md
@@ -18,3 +18,8 @@
 | 1.1.1.1 (Cloudflare DNS) | allow (L4) | - |
 | 8.8.8.8 (Google Public DNS) | allow (L4) | - |
 | 8.8.4.4 (Google Public DNS)  | deny (L4) | - |
+
+| Source | To self (Ingress) |
+|-|-|
+| 10.100.0.0/16 | allow (L3) |
+| 192.168.100.0/24 | deny (L4) |

--- a/e2e/testdata/policy/l3.yaml
+++ b/e2e/testdata/policy/l3.yaml
@@ -20,11 +20,14 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   namespace: test
-  name: l3-egress
+  name: l3-self
 spec:
   endpointSelector:
     matchLabels:
       k8s:test: self
+  ingress:
+    - fromCIDR:
+        - 10.100.0.0/16
   egress:
     - toEndpoints:
         - matchLabels:

--- a/e2e/testdata/policy/l4.yaml
+++ b/e2e/testdata/policy/l4.yaml
@@ -2,11 +2,18 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   namespace: test
-  name: l4-egress
+  name: l4-self
 spec:
   endpointSelector:
     matchLabels:
       k8s:test: self
+  ingressDeny:
+    - fromCIDR:
+        - 192.168.100.0/24
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
   egress:
     - toEndpoints:
         - matchLabels:

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -61,41 +61,46 @@ func testTraffic() {
 		}
 
 		cases := []struct {
-			Selector string
+			Args     []string
 			Expected string
 		}{
 			{
-				Selector: l3PodName,
+				Args:     []string{l3PodName},
 				Expected: `Ingress,,self,true,true,0,0`,
 			},
 			{
-				Selector: l4PodName,
+				Args:     []string{l4PodName},
 				Expected: `Ingress,,self,false,false,6,8000`,
 			},
 			{
-				Selector: selfNames[0],
+				Args: []string{selfNames[0]},
 				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
 Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53`,
 			},
 			{
-				Selector: selfNames[1],
+				Args: []string{selfNames[1]},
 				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
 Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 			},
 			{
-				Selector: "-l=test=self",
+				Args: []string{"-l=test=self"},
 				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
 Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53
 Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 			},
+			{
+				Args:     []string{"-l=test=self", "--with-cidr=8.0.0.0/8"},
+				Expected: `Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
+			},
 		}
 		for _, c := range cases {
-			result := runViewerSafe(Default, nil, "traffic", "-o=json", "-n=test", c.Selector)
+			args := append([]string{"traffic", "-o=json", "-n=test"}, c.Args...)
+			result := runViewerSafe(Default, nil, args...)
 			resultString := formatTrafficResult(result, false)
-			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nactual: %s\nexpected: %s", c.Selector, resultString, c.Expected)
+			Expect(resultString).To(Equal(c.Expected), "compare failed. args: %v\nactual: %s\nexpected: %s", c.Args, resultString, c.Expected)
 		}
 
 		By("checking npv traffic -l shows combined traffic amount")

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -92,7 +92,7 @@ Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53
 Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 			},
 			{
-				Args:     []string{"-l=test=self", "--with-cidr=8.0.0.0/8"},
+				Args:     []string{"-l=test=self", "--with-cidrs=8.0.0.0/8"},
 				Expected: `Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 			},
 		}


### PR DESCRIPTION
This PR adds `--with-cidrs`, `--with-private-cidrs`, and `--with-public-cidrs` options to inspect and traffic commands.
- `npv inspect --with-cidrs <comma-separated CIDRs>` shows rules for the CIDRs.
- `npv traffic --with-cidrs <comma-separated CIDRs>` shows traffic volume for the CIDRs.

`--with-cidrs` accepts comma-separated CIDRs with exclusion mark `!`, so the following specifications are all valid.
- `--with-cidrs 8.0.0.0/8`
- `--with-cidrs 8.8.4.4/32,8.8.8.8/32`
- `--with-cidrs 8.0.0.0/8,\!8.8.8.8/32`

This syntax follows `kubectl get -l`.
```
root@ubuntu-6cb57548bf-glwst:/# kubectl get po -n test -l group=test,test=self
NAME                    READY   STATUS    RESTARTS   AGE
self-7b54c7b648-7bkj4   1/1     Running   0          21m
self-7b54c7b648-npmzj   1/1     Running   0          21m

root@ubuntu-6cb57548bf-glwst:/# kubectl get po -n test -l 'group=test,!test'
No resources found in test namespace.
```

`--with-private-cidrs` is the shorthand for `--with-cidrs '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'`.
`--with-public-cidrs` is the shorthand for `--with-cidrs '0.0.0.0/0,!10.0.0.0/8,!172.16.0.0/12,!192.168.0.0/16'`.

Example output:
```
root@ubuntu-6cb57548bf-gmqjs:/# npv inspect -n test self-7b54c7b648-g9ntp --with-public-cidrs 
POLICY DIRECTION IDENTITY NAMESPACE EXAMPLE         PROTOCOL PORT BYTES REQUESTS AVERAGE
Deny   Egress    16777221 -         cidr:8.8.4.4/32 SCTP     53   0     0        0.0
Deny   Egress    16777221 -         cidr:8.8.4.4/32 TCP      53   0     0        0.0
Deny   Egress    16777221 -         cidr:8.8.4.4/32 UDP      53   0     0        0.0
Allow  Egress    16777219 -         cidr:1.1.1.1/32 SCTP     53   0     0        0.0
Allow  Egress    16777219 -         cidr:1.1.1.1/32 UDP      53   186   2        93.0
Allow  Egress    16777219 -         cidr:1.1.1.1/32 TCP      53   0     0        0.0
Allow  Egress    16777220 -         cidr:8.8.8.8/32 SCTP     53   0     0        0.0
Allow  Egress    16777220 -         cidr:8.8.8.8/32 UDP      53   0     0        0.0
Allow  Egress    16777220 -         cidr:8.8.8.8/32 TCP      53   0     0        0.0

root@ubuntu-6cb57548bf-gmqjs:/# npv inspect -n test self-7b54c7b648-g9ntp --with-private-cidrs 
POLICY DIRECTION IDENTITY NAMESPACE EXAMPLE               PROTOCOL PORT BYTES REQUESTS AVERAGE
Deny   Ingress   16777218 -         cidr:192.168.100.0/24 TCP      8080 0     0        0.0
Allow  Ingress   16777217 -         cidr:10.100.0.0/16    ANY      ANY  0     0        0.0
```

I'm a little bit concerning about the brevity vs consistency of the parameter names. Possible choices are:
1. keep current names (`--with-cidr`, `--with-private-cidrs`, `--with-public-cidrs`)
2. use `--with-cidrs`, `--with-private-cidrs`, `--with-public-cidrs`
3. use `--with-cidr`, `--with-private-cidr`, `--with-public-cidr`

How do you think which one is best?

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
