### PR TITLE
Add label selector to list command

### DIFF
--- a/cmd/npv/app/helper_completion.go
+++ b/cmd/npv/app/helper_completion.go
@@ -57,7 +57,7 @@ func completePods(cmd *cobra.Command, args []string, toComplete string) (ret []s
 		return
 	}
 
-	pods, err := listRelevantPods(context.Background(), clientset, getRelevantNamespace(), metav1.ListOptions{})
+	pods, err := listCiliumManagedPods(context.Background(), clientset, getSubjectNamespace(), metav1.ListOptions{})
 	if err != nil {
 		return
 	}
@@ -80,7 +80,7 @@ func completeNamespacePods(cmd *cobra.Command, args []string, toComplete string)
 	li := strings.Split(toComplete, "/")
 	switch len(li) {
 	case 2: // namespace already filled
-		pods, err := listRelevantPods(context.Background(), clientset, li[0], metav1.ListOptions{})
+		pods, err := listCiliumManagedPods(context.Background(), clientset, li[0], metav1.ListOptions{})
 		if err != nil {
 			return
 		}

--- a/cmd/npv/app/summary.go
+++ b/cmd/npv/app/summary.go
@@ -49,7 +49,7 @@ func runSummary(ctx context.Context, w io.Writer) error {
 	}
 
 	summary := make([]summaryEntry, 0)
-	pods, err := listRelevantPods(ctx, clientset, getRelevantNamespace(), metav1.ListOptions{})
+	pods, err := listCiliumManagedPods(ctx, clientset, getSubjectNamespace(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -99,6 +99,27 @@ Ingress,CiliumNetworkPolicy,test,l4-ingress-all-allow-tcp`,
 	})
 }
 
+func testListAll() {
+	expected := `Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+Egress,CiliumNetworkPolicy,test,l3-egress
+Egress,CiliumNetworkPolicy,test,l4-egress
+Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-allow-all
+Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-deny-all
+Ingress,CiliumNetworkPolicy,test,l4-ingress-all-allow-tcp
+Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-allow-any
+Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-allow-tcp
+Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-deny-any
+Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-deny-udp`
+
+	It("should list applied policies for multiple pods", func() {
+		result := runViewerSafe(Default, nil, "list", "-o=json", "-n=test")
+		result = jqSafe(Default, result, "-r", ".[] | [.direction, .kind, .namespace, .name] | @csv")
+		resultString := strings.Replace(string(result), `"`, "", -1)
+		Expect(resultString).To(Equal(expected), "compare failed. actual: %s\nexpected: %s", resultString, expected)
+	})
+}
+
 func testListManifests() {
 	expected := `apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Test network-policy-viewer", func() {
 func runTest() {
 	Context("dump", testDump)
 	Context("list", testList)
+	Context("list-all", testListAll)
 	Context("list-manifests", testListManifests)
 	Context("id-label", testIdLabel)
 	Context("id-summary", testIdSummary)


### PR DESCRIPTION
This PR allows `npv list` to select multiple pods using `-A`, `-n`, and `-l` options.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
