### PR TITLE
Add --units option

### DIFF
--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -186,6 +186,28 @@ func parseNamespacedName(nn string) (types.NamespacedName, error) {
 	return types.NamespacedName{Namespace: li[0], Name: li[1]}, nil
 }
 
+func formatWithUnits(v int) string {
+	if v < 1024 || !rootOptions.units {
+		return strconv.Itoa(v)
+	}
+
+	units := "_KMGTPEZY"
+	i := 0
+	fv := float64(v)
+	for fv >= 1024 {
+		i += 1
+		fv /= 1024
+	}
+	return fmt.Sprintf("%.1f%c", fv, units[i])
+}
+
+func computeAverage(bytes, count int) float64 {
+	if count == 0 {
+		return 0
+	}
+	return float64(bytes) / float64(count)
+}
+
 func writeSimpleOrJson(w io.Writer, content any, header []string, count int, values func(index int) []any) error {
 	switch rootOptions.output {
 	case OutputJson:

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -22,6 +22,7 @@ var rootOptions struct {
 	proxyPort      uint16
 	output         string
 	noHeaders      bool
+	units          bool
 }
 
 func init() {
@@ -33,6 +34,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint16Var(&rootOptions.proxyPort, "proxy-port", 8080, "port number of the proxy endpoints")
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", OutputSimple, "output format")
 	rootCmd.PersistentFlags().BoolVar(&rootOptions.noHeaders, "no-headers", false, "stop printing header")
+	rootCmd.PersistentFlags().BoolVarP(&rootOptions.units, "units", "u", false, "use human-readable units (power of 1024) for traffic volume")
 	rootCmd.RegisterFlagCompletionFunc("namespace", completeNamespaces)
 	rootCmd.RegisterFlagCompletionFunc("node", completeNodes)
 }


### PR DESCRIPTION
This PR:
- adds `-u (--units)` option to format the number of packets and requests
  - it uses power of 1024 instead of 1000.
  - Although 1kpbs = 1000bps, the `BYTES` column shows the total volume instead of speed. So it looks more reasonable to use 1024
- renames `PACKETS` column to `REQUESTS` because it is the number of requests Cilium handles, instead of the number of packets on NICs
- adds `AVERAGE` column to show average request size

Example output:
```
npv traffic -n test self-7b54c7b648-tkcql -u 
DIRECTION IDENTITY NAMESPACE EXAMPLE                                        PROTOCOL PORT BYTES REQUESTS AVERAGE
Egress    2        -         cidr:1.1.1.1/32                                UDP      53   279   3        93.0
Egress    959      test      l3-ingress-explicit-allow-all-854c9bb96c-6xhhq ANY      ANY  1.4K  18       80.7
Egress    31472    test      l4-ingress-explicit-allow-tcp-674bf84548-zmh6b TCP      8000 1.4K  18       80.8
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
