### PR TITLE
Right-align traffic volume

### DIFF
--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -138,7 +138,7 @@ func runInspect(ctx context.Context, w io.Writer, name string) error {
 	}
 
 	// I don't know it is safe to sort the result of "cilium bpf policy get", so let's keep the original order.
-	header := []string{"POLICY", "DIRECTION", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "BYTES", "REQUESTS", "AVERAGE"}
+	header := []string{"POLICY", "DIRECTION", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "|", "BYTES:", "REQUESTS:", "AVERAGE:"}
 	return writeSimpleOrJson(w, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		var protocol, port string
@@ -153,6 +153,6 @@ func runInspect(ctx context.Context, w io.Writer, name string) error {
 			port = strconv.Itoa(p.Port)
 		}
 		avg := fmt.Sprintf("%.1f", computeAverage(p.Bytes, p.Requests))
-		return []any{p.Policy, p.Direction, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
+		return []any{p.Policy, p.Direction, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, "|", formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
 	})
 }

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -274,7 +274,7 @@ func runReach(ctx context.Context, w io.Writer) error {
 		}
 	}
 
-	header := []string{"ROLE", "DIRECTION", "POLICY", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "BYTES", "REQUESTS", "AVERAGE"}
+	header := []string{"ROLE", "DIRECTION", "POLICY", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "|", "BYTES:", "REQUESTS:", "AVERAGE:"}
 	return writeSimpleOrJson(w, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		var protocol, port string
@@ -289,6 +289,6 @@ func runReach(ctx context.Context, w io.Writer) error {
 			port = strconv.Itoa(p.Port)
 		}
 		avg := fmt.Sprintf("%.1f", computeAverage(p.Bytes, p.Requests))
-		return []any{p.Role, p.Direction, p.Policy, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
+		return []any{p.Role, p.Direction, p.Policy, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, "|", formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
 	})
 }

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -195,7 +195,7 @@ func runTraffic(ctx context.Context, w io.Writer, name string) error {
 	}
 	sort.Slice(arr, func(i, j int) bool { return lessTrafficEntry(&arr[i], &arr[j]) })
 
-	header := []string{"DIRECTION", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "BYTES", "REQUESTS", "AVERAGE"}
+	header := []string{"DIRECTION", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "|", "BYTES:", "REQUESTS:", "AVERAGE:"}
 	return writeSimpleOrJson(w, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		var protocol, port string
@@ -210,6 +210,6 @@ func runTraffic(ctx context.Context, w io.Writer, name string) error {
 			port = strconv.Itoa(p.Port)
 		}
 		avg := fmt.Sprintf("%.1f", computeAverage(p.Bytes, p.Requests))
-		return []any{p.Direction, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
+		return []any{p.Direction, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, "|", formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
 	})
 }


### PR DESCRIPTION
This PR makes `BYTES`, `PACKETS`, and `AVERAGE` columns right-aligned.

```
root@ubuntu-6cb57548bf-6hlbt:/# npv traffic -Au
DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT |  BYTES  REQUESTS  AVERAGE
Egress    | 0        -         reserved:unknown                               | ANY      ANY  |   2.5M     17.9K    143.3
Egress    | 2        -         cidr:1.1.1.1/32                                | UDP      53   |    279         3     93.0
Egress    | 2        -         cidr:8.8.8.8/32                                | UDP      53   |    279         3     93.0
Egress    | 19000    test      l4-ingress-explicit-allow-tcp-674bf84548-rjx6x | TCP      8000 |   2.8K        36     80.8
Egress    | 40870    test      l3-ingress-explicit-allow-all-854c9bb96c-pdc6w | ANY      ANY  |   2.8K        36     80.7
Ingress   | 0        -         reserved:unknown                               | ANY      ANY  | 312.6K      3.2K     98.7
Ingress   | 1        -         reserved:host                                  | ANY      ANY  |  63.6K       750     86.9
Ingress   | 21256    test      self-7b54c7b648-dcsb5                          | ANY      ANY  |   2.8K        36     80.7
Ingress   | 21256    test      self-7b54c7b648-582tx                          | TCP      8000 |   2.8K        36     80.8
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
