### PR TITLE
Implement basic filter

### DIFF
--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -258,7 +258,8 @@ func writeSimpleOrJson(w io.Writer, content any, header []string, count int, val
 		for j := 0; j < len(header); j++ {
 			h := header[j]
 			if strings.HasSuffix(h, ":") {
-				header[j] = h[:len(h)-1]
+				h = h[:len(h)-1]
+				header[j] = h
 				width := len(h)
 				for i := 0; i < count; i++ {
 					v := fmt.Sprintf("%v", expr[i][j])

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -96,6 +96,34 @@ Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
 Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		},
 		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--allowed", "--ingress"},
+			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
+Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--denied", "--egress"},
+			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
+Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
+Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
+		},
+		{
+			Selector:  "test=l4-ingress-explicit-allow-tcp",
+			ExtraArgs: []string{"--used"},
+			Expected:  `Allow,Ingress,self,false,false,6,8000`,
+		},
+		{
+			Selector:  "test=l4-ingress-explicit-deny-udp",
+			ExtraArgs: []string{"--denied", "--unused"},
+			Expected:  `Deny,Ingress,self,false,false,17,161`,
+		},
+		{
 			Selector: "test=l3-ingress-explicit-allow-all",
 			Expected: `Allow,Ingress,reserved:host,true,true,0,0
 Allow,Ingress,self,true,true,0,0`,

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,11 +18,29 @@ func Test(t *testing.T) {
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(time.Second)
 	SetDefaultEventuallyTimeout(5 * time.Minute)
+
+	processTestTraffic()
 })
 
 var _ = Describe("Test network-policy-viewer", func() {
 	runTest()
 })
+
+func processTestTraffic() {
+	data := kubectlSafe(Default, nil, "get", "pod", "-n=test", "-l=test=self", "-o=jsonpath={.items[*].metadata.name}")
+	selfNames := strings.Fields(string(data))
+	l3PodName := onePodByLabelSelector(Default, "test", "test=l3-ingress-explicit-allow-all")
+	l4PodName := onePodByLabelSelector(Default, "test", "test=l4-ingress-explicit-allow-tcp")
+	l3PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l3PodName, "-o=jsonpath={.status.podIP}"))
+	l4PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l4PodName, "-o=jsonpath={.status.podIP}"))
+
+	kubectlSafe(Default, nil, "exec", "-n=test", selfNames[0], "--", "dig", "@1.1.1.1", "google.com")
+	kubectlSafe(Default, nil, "exec", "-n=test", selfNames[1], "--", "dig", "@8.8.8.8", "google.com")
+	for _, p := range selfNames {
+		kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l3PodIP))
+		kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l4PodIP))
+	}
+}
 
 func runTest() {
 	Context("dump", testDump)

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"bufio"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -50,15 +49,6 @@ func testTraffic() {
 		selfNames := strings.Fields(string(data))
 		l3PodName := onePodByLabelSelector(Default, "test", "test=l3-ingress-explicit-allow-all")
 		l4PodName := onePodByLabelSelector(Default, "test", "test=l4-ingress-explicit-allow-tcp")
-		l3PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l3PodName, "-o=jsonpath={.status.podIP}"))
-		l4PodIP := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", l4PodName, "-o=jsonpath={.status.podIP}"))
-
-		kubectlSafe(Default, nil, "exec", "-n=test", selfNames[0], "--", "dig", "@1.1.1.1", "google.com")
-		kubectlSafe(Default, nil, "exec", "-n=test", selfNames[1], "--", "dig", "@8.8.8.8", "google.com")
-		for _, p := range selfNames {
-			kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l3PodIP))
-			kubectlSafe(Default, nil, "exec", "-n=test", p, "--", "curl", fmt.Sprintf("http://%s:8000", l4PodIP))
-		}
 
 		cases := []struct {
 			Args     []string


### PR DESCRIPTION
This PR adds basic filter options to `npv inspect`.
It implements the following options.
- `--ingress`, `--egress`
- `--allowed`, `--denied`
- `--used`, `--unused`

```
root@ubuntu-6cb57548bf-mlh4h:/# npv inspect -n test self-7b54c7b648-n9nmp --allowed --egress --used
POLICY DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
Allow  Egress    | 16715    test      l3-ingress-explicit-allow-all-854c9bb96c-4gxqb | ANY      ANY  |   970       12    80.8
Allow  Egress    | 29923    test      l4-ingress-explicit-allow-tcp-674bf84548-wb5xs | TCP      8000 |   968       12    80.7
Allow  Egress    | 16777219 -         cidr:1.1.1.1/32                                | UDP      53   |   186        2    93.0
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
