### PR TITLE
Implement npv id tree

### DIFF
--- a/cmd/npv/app/id_tree.go
+++ b/cmd/npv/app/id_tree.go
@@ -1,0 +1,196 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"math"
+	"slices"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func init() {
+	idCmd.AddCommand(idTreeCmd)
+}
+
+var idTreeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Display CiliumIdentity hierarchy",
+	Long:  `Display CiliumIdentity hierarchy`,
+
+	Args: cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runIdTree(context.Background(), cmd.OutOrStdout())
+	},
+}
+
+type idTreeEntry struct {
+	identity int
+	labels   map[string]string
+}
+
+func runIdTree(ctx context.Context, w io.Writer) error {
+	_, dynamicClient, err := createK8sClients()
+	if err != nil {
+		return err
+	}
+
+	li, err := dynamicClient.Resource(gvrIdentity).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	items := make([]idTreeEntry, 0)
+	for _, item := range li.Items {
+		var e idTreeEntry
+		id, err := strconv.Atoi(item.GetName())
+		if err != nil {
+			return err
+		}
+		e.identity = id
+
+		labels, ok, err := unstructured.NestedStringMap(item.Object, "security-labels")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if ns, ok := labels["k8s:io.kubernetes.pod.namespace"]; ok {
+			if !(rootOptions.allNamespaces || ns == rootOptions.namespace) {
+				continue
+			}
+		}
+		e.labels = labels
+		items = append(items, e)
+	}
+
+	idEndpoints, err := getIdentityEndpoints(ctx, dynamicClient)
+	if err != nil {
+		return err
+	}
+
+	return walkIdTree(w, items, idEndpoints, "")
+}
+
+func computeLabelMap(entries []idTreeEntry) map[string][]string {
+	var keys []string
+	{
+		keyMap := make(map[string]any)
+		for _, e := range entries {
+			for k := range e.labels {
+				keyMap[k] = struct{}{}
+			}
+		}
+		keys = slices.Collect(maps.Keys(keyMap))
+	}
+
+	ret := make(map[string][]string)
+	for _, k := range keys {
+		values := make(map[string]any)
+		for _, e := range entries {
+			values[e.labels[k]] = struct{}{}
+		}
+		ret[k] = slices.Collect(maps.Keys(values))
+		slices.Sort(ret[k])
+	}
+	return ret
+}
+
+func findPrimaryKey(labelMap map[string][]string) (key string, cardinality int) {
+	special := []string{
+		"k8s:io.cilium.k8s.policy.cluster",
+		"k8s:io.kubernetes.pod.namespace",
+	}
+	for _, k := range special {
+		if v, ok := labelMap[k]; ok {
+			key = k
+			cardinality = len(v)
+			return
+		}
+	}
+
+	keys := slices.Collect(maps.Keys(labelMap))
+	slices.Sort(keys)
+
+	key = ""
+	cardinality = math.MaxInt32
+	for _, k := range keys {
+		v := labelMap[k]
+		if len(v) < cardinality {
+			key = k
+			cardinality = len(v)
+		}
+	}
+	return key, cardinality
+}
+
+// ref. https://github.com/cybozu-go/accurate/blob/main/cmd/kubectl-accurate/sub/list.go
+func walkIdTree(w io.Writer, entries []idTreeEntry, idEndpoints map[int][]*unstructured.Unstructured, prefix string) error {
+	cleanup := func(li []idTreeEntry, key string) {
+		for _, e := range li {
+			delete(e.labels, key)
+		}
+	}
+
+	labelMap := computeLabelMap(entries)
+	if len(labelMap) == 0 {
+		eps := make([]string, 0)
+		for _, entry := range entries {
+			for _, ep := range idEndpoints[entry.identity] {
+				eps = append(eps, ep.GetName())
+			}
+		}
+		slices.Sort(eps)
+		for i, ep := range eps {
+			isLast := i == len(eps)-1
+			if !isLast {
+				fmt.Println(prefix + "├── " + ep)
+			} else {
+				fmt.Println(prefix + "└── " + ep)
+			}
+		}
+		return nil
+	}
+
+	key, cardinality := findPrimaryKey(labelMap)
+
+	switch cardinality {
+	case 1:
+		fmt.Println(prefix + key + "=" + labelMap[key][0])
+		cleanup(entries, key)
+		walkIdTree(w, entries, idEndpoints, prefix)
+	default:
+		fmt.Println(prefix + key)
+		values := labelMap[key]
+
+		for i, v := range values {
+			children := make([]idTreeEntry, 0)
+			for _, e := range entries {
+				if e.labels[key] == v {
+					children = append(children, e)
+				}
+			}
+			if v == "" {
+				v = "(null)"
+			}
+
+			isLast := i == len(values)-1
+			if !isLast {
+				fmt.Println(prefix + "├── " + v)
+				cleanup(children, key)
+				walkIdTree(w, children, idEndpoints, prefix+"│   ")
+			} else {
+				fmt.Println(prefix + "└── " + v)
+				cleanup(children, key)
+				walkIdTree(w, children, idEndpoints, prefix+"    ")
+			}
+		}
+	}
+	return nil
+}

--- a/e2e/id_test.go
+++ b/e2e/id_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -119,5 +120,56 @@ func testIdSummary() {
 			// Multiple CiliumIdentities may be generated for a same set of security-relevant labels
 			Expect(result).To(BeNumerically(">=", expected), "compare failed. namespace: %s\nactual: %d\nexpected: %d", result, expected)
 		}
+	})
+}
+
+func testIdTree() {
+	expected := `k8s:io.cilium.k8s.policy.cluster=default
+k8s:io.kubernetes.pod.namespace=test
+k8s:group=test
+k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=test
+k8s:io.cilium.k8s.policy.serviceaccount=default
+k8s:test
+├── l3-egress-explicit-deny-all
+│   └── l3-egress-explicit-deny-all
+├── l3-egress-implicit-deny-all
+│   └── l3-egress-implicit-deny-all
+├── l3-ingress-explicit-allow-all
+│   ├── l3-ingress-explicit-allow-all
+│   └── l3-ingress-explicit-allow-all
+├── l3-ingress-explicit-deny-all
+│   └── l3-ingress-explicit-deny-all
+├── l3-ingress-implicit-deny-all
+│   └── l3-ingress-implicit-deny-all
+├── l4-egress-explicit-deny-any
+│   └── l4-egress-explicit-deny-any
+├── l4-egress-explicit-deny-tcp
+│   └── l4-egress-explicit-deny-tcp
+├── l4-ingress-all-allow-tcp
+│   └── l4-ingress-all-allow-tcp
+├── l4-ingress-explicit-allow-any
+│   └── l4-ingress-explicit-allow-any
+├── l4-ingress-explicit-allow-tcp
+│   └── l4-ingress-explicit-allow-tcp
+├── l4-ingress-explicit-deny-any
+│   └── l4-ingress-explicit-deny-any
+├── l4-ingress-explicit-deny-udp
+│   └── l4-ingress-explicit-deny-udp
+└── self
+    ├── self
+    └── self
+`
+
+	It("should show id tree", func() {
+		podPattern, err := regexp.Compile("(?P<group>[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+-[[:alnum:]]+)-[[:alnum:]]+-[[:alnum:]]+")
+		Expect(err).NotTo(HaveOccurred())
+
+		selfPattern, err := regexp.Compile("self-[[:alnum:]]+-[[:alnum:]]+")
+		Expect(err).NotTo(HaveOccurred())
+
+		result := runViewerSafe(Default, nil, "id", "tree", "-n=test")
+		result = podPattern.ReplaceAll(result, []byte("${1}"))
+		result = selfPattern.ReplaceAll(result, []byte("self"))
+		Expect(string(result)).To(Equal(expected))
 	})
 }

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -49,6 +49,7 @@ func runTest() {
 	Context("list-manifests", testListManifests)
 	Context("id-label", testIdLabel)
 	Context("id-summary", testIdSummary)
+	Context("id-tree", testIdTree)
 	Context("inspect", testInspect)
 	Context("summary", testSummary)
 	Context("summary-all", testSummaryAll)


### PR DESCRIPTION
This PR implements `npv id tree`, that shows us how security-relevant labels organize CiliumIdentity and CiliumEndpoint.

Example output:
```
root@ubuntu-6cb57548bf-vm5xb:/# npv id tree -A
k8s:io.cilium.k8s.policy.cluster=default # If all endpoints share a same key-value pair, it is shown as "A=B".
k8s:io.kubernetes.pod.namespace          # If a security-relevant label has multiple values, it is shown as tree under the label name.
├── cilium-agent-proxy                   # Each node shows respective label value
│   k8s:app.kubernetes.io/name=cilium-agent-proxy # Under this node, all the endpoints share a same key-value pair
│   k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=cilium-agent-proxy # ditto
│   k8s:io.cilium.k8s.policy.serviceaccount=default                                   # ditto
│   ├── cilium-agent-proxy-6xc5x # After enumerating all the security-relevant labels, list CiliumEndpoints under this node.
│   ├── cilium-agent-proxy-l7s4z
│   └── cilium-agent-proxy-rk268
├── default
│   k8s:app=ubuntu
│   k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default
│   k8s:io.cilium.k8s.policy.serviceaccount=ubuntu
│   └── ubuntu-6cb57548bf-vm5xb
├── kube-system
│   k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system
│   k8s:io.cilium.k8s.policy.serviceaccount=coredns
│   k8s:k8s-app=kube-dns
│   ├── coredns-668d6bf9bc-h6z24
│   └── coredns-668d6bf9bc-h88n7
├── local-path-storage
│   k8s:app=local-path-provisioner
│   k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=local-path-storage
│   k8s:io.cilium.k8s.policy.serviceaccount=local-path-provisioner-service-account
│   └── local-path-provisioner-7dc846544d-k9pgh
└── test
    k8s:group=test
    k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=test
    k8s:io.cilium.k8s.policy.serviceaccount=default
    k8s:test
    ├── l3-egress-explicit-deny-all
    │   └── l3-egress-explicit-deny-all-5ccc4bc694-bsr6q
    ├── l3-egress-implicit-deny-all
    │   └── l3-egress-implicit-deny-all-5599dbdbc5-sbcfh
    ├── l3-ingress-explicit-allow-all
    │   ├── l3-ingress-explicit-allow-all-854c9bb96c-97dq8
    │   └── l3-ingress-explicit-allow-all-854c9bb96c-hm27r
    ├── l3-ingress-explicit-deny-all
    │   └── l3-ingress-explicit-deny-all-989846d5d-cws4x
    ├── l3-ingress-implicit-deny-all
    │   └── l3-ingress-implicit-deny-all-75cc75f9ff-562gr
    ├── l4-egress-explicit-deny-any
    │   └── l4-egress-explicit-deny-any-76664b65c6-xdct6
    ├── l4-egress-explicit-deny-tcp
    │   └── l4-egress-explicit-deny-tcp-58458f767c-rq5t8
    ├── l4-ingress-all-allow-tcp
    │   └── l4-ingress-all-allow-tcp-c767885c7-28f2p
    ├── l4-ingress-explicit-allow-any
    │   └── l4-ingress-explicit-allow-any-7f4dd8757c-hb2mv
    ├── l4-ingress-explicit-allow-tcp
    │   └── l4-ingress-explicit-allow-tcp-674bf84548-sscvw
    ├── l4-ingress-explicit-deny-any
    │   └── l4-ingress-explicit-deny-any-5d89b68bfd-8ss56
    ├── l4-ingress-explicit-deny-udp
    │   └── l4-ingress-explicit-deny-udp-7cd9cb8f47-cwj9x
    └── self
        ├── self-7b54c7b648-k5jl9
        └── self-7b54c7b648-wbxxl

```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
