### PR TITLE
Allow npv inspect to query multiple pods

### DIFF
--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -15,7 +15,18 @@ func testInspect() {
 	}{
 		{
 			Selector: "test=self",
-			Expected: `Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
+			Expected: `Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080
+Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
+Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
+Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000
+Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
+Allow,Ingress,reserved:host,true,true,0,0
+Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
 Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
 Allow,Egress,cidr:1.1.1.1/32,false,false,132,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
@@ -31,28 +42,17 @@ Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,6,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,17,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,132,53
-Allow,Egress,l4-ingress-explicit-deny-udp,false,false,17,161
-Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
-Allow,Ingress,reserved:host,true,true,0,0
-Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
-Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
-Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
-Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
-Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
-Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000
-Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,
+Allow,Egress,l4-ingress-explicit-deny-udp,false,false,17,161`,
 		},
 		{
 			Selector:  "test=self",
 			ExtraArgs: []string{"--with-cidrs=8.8.0.0/16"},
-			Expected: `Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
-Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
-Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
 Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
@@ -79,21 +79,21 @@ Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
 		{
 			Selector:  "test=self",
 			ExtraArgs: []string{"--with-private-cidrs"},
-			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
-Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080`,
+			Expected: `Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080
+Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0`,
 		},
 		{
 			Selector:  "test=self",
 			ExtraArgs: []string{"--with-public-cidrs"},
-			Expected: `Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
+			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
 Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
 Allow,Egress,cidr:1.1.1.1/32,false,false,132,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
-Allow,Egress,cidr:8.8.8.8/32,false,false,132,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,132,53`,
+Allow,Egress,cidr:8.8.8.8/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
@@ -134,8 +134,8 @@ Allow,Ingress,self,true,true,0,0`,
 		},
 		{
 			Selector: "test=l3-ingress-explicit-deny-all",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Deny,Ingress,self,true,true,0,0`,
+			Expected: `Deny,Ingress,self,true,true,0,0
+Allow,Ingress,reserved:host,true,true,0,0`,
 		},
 		{
 			Selector: "test=l3-egress-implicit-deny-all",
@@ -159,15 +159,15 @@ Allow,Ingress,self,false,false,6,8000`,
 		},
 		{
 			Selector: "test=l4-ingress-explicit-deny-any",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Deny,Ingress,self,false,false,6,53
+			Expected: `Deny,Ingress,self,false,false,6,53
 Deny,Ingress,self,false,false,17,53
-Deny,Ingress,self,false,false,132,53`,
+Deny,Ingress,self,false,false,132,53
+Allow,Ingress,reserved:host,true,true,0,0`,
 		},
 		{
 			Selector: "test=l4-ingress-explicit-deny-udp",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Deny,Ingress,self,false,false,17,161`,
+			Expected: `Deny,Ingress,self,false,false,17,161
+Allow,Ingress,reserved:host,true,true,0,0`,
 		},
 		{
 			Selector: "test=l4-egress-explicit-deny-any",
@@ -179,22 +179,35 @@ Deny,Ingress,self,false,false,17,161`,
 		},
 		{
 			Selector: "test=l4-ingress-all-allow-tcp",
-			Expected: `Allow,Ingress,reserved:host,false,false,6,8000
-Allow,Ingress,reserved:host,true,true,0,0
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0
+Allow,Ingress,reserved:host,false,false,6,8000
 Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		{
+			ExtraArgs: []string{"--used"},
+			Expected: `Allow,Ingress,self,true,true,0,0
+Allow,Ingress,self,false,false,6,8000
+Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
+Allow,Egress,l3-ingress-explicit-allow-all,true,true,0,0
+Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000
+Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
+Allow,Egress,l3-ingress-explicit-allow-all,true,true,0,0
+Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000`,
 		},
 	}
 
 	It("should inspect policy configuration", func() {
 		for _, c := range cases {
-			podName := onePodByLabelSelector(Default, "test", c.Selector)
-			args := append([]string{"inspect", "-o=json", "-n=test", podName}, c.ExtraArgs...)
+			args := []string{"inspect", "-o=json", "-n=test"}
+			if c.Selector != "" {
+				podName := onePodByLabelSelector(Default, "test", c.Selector)
+				args = append(args, podName)
+			}
+			args = append(args, c.ExtraArgs...)
 			result := runViewerSafe(Default, nil, args...)
 			// remove hash suffix from pod names
 			result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | split("-") | .[0:5] | join("-"))]`)
 			result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | if startswith("self") then "self" else . end)]`)
-			// "npv inspect" returns a unstable result, so we need to sort it in test
-			result = jqSafe(Default, result, "-r", `sort_by(.policy, .direction, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port)`)
 			result = jqSafe(Default, result, "-r", `.[] | [.policy, .direction, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port] | @csv`)
 			resultString := strings.Replace(string(result), `"`, "", -1)
 			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nargs: %v\nactual: %s\nexpected: %s", c.Selector, c.ExtraArgs, resultString, c.Expected)


### PR DESCRIPTION
This PR allows `npv inspect` to query policy maps of multiple pods at once.
When a user asks `npv` to query multiple policy maps, `SUBJECT` column shows up and indicate which pod each rule belongs to. 

This function is particularly useful in the following situations.
- It returns detailed traffic information than `npv traffic`. (Use `npv inspect -n <NAMESPACE> --used)`
- It is faster in querying multiple policy maps than `for p in $(...); do npv inspect $p; done`, because it uses in-memory cache for node-local identity information.

```
root@ubuntu-6cb57548bf-8tzxl:/# npv inspect -n test --used
SUBJECT                                        | POLICY DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
l3-ingress-explicit-allow-all-854c9bb96c-8rpf2 | Allow  Ingress   | 14057    test      self-7b54c7b648-m7dls                          | ANY      ANY  |   970       12    80.8
l4-ingress-explicit-allow-tcp-674bf84548-lvxc9 | Allow  Ingress   | 14057    test      self-7b54c7b648-m7dls                          | TCP      8000 |   968       12    80.7
self-7b54c7b648-67lh7                          | Allow  Egress    | 16777219 -         cidr:1.1.1.1/32                                | UDP      53   |    93        1    93.0
self-7b54c7b648-67lh7                          | Allow  Egress    | 48722    test      l3-ingress-explicit-allow-all-854c9bb96c-zwkpn | ANY      ANY  |   485        6    80.8
self-7b54c7b648-67lh7                          | Allow  Egress    | 32171    test      l4-ingress-explicit-allow-tcp-674bf84548-lvxc9 | TCP      8000 |   484        6    80.7
self-7b54c7b648-m7dls                          | Allow  Egress    | 16777222 -         cidr:8.8.8.8/32                                | UDP      53   |    93        1    93.0
self-7b54c7b648-m7dls                          | Allow  Egress    | 48722    test      l3-ingress-explicit-allow-all-854c9bb96c-zwkpn | ANY      ANY  |   485        6    80.8
self-7b54c7b648-m7dls                          | Allow  Egress    | 32171    test      l4-ingress-explicit-allow-tcp-674bf84548-lvxc9 | TCP      8000 |   484        6    80.7
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
