### PR TITLE
Add flag to unify cluster-external traffic

### DIFF
--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -12,6 +12,12 @@ import (
 	"text/tabwriter"
 )
 
+var privateCIDRs []*net.IPNet
+
+func init() {
+	privateCIDRs, _, _ = parseCIDRFlag("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16")
+}
+
 func parseCIDRFlag(expr string) (incl []*net.IPNet, excl []*net.IPNet, err error) {
 	incl = make([]*net.IPNet, 0)
 	excl = make([]*net.IPNet, 0)
@@ -54,6 +60,24 @@ func isChildCIDR(parent, child *net.IPNet) bool {
 	p, _ := parent.Mask.Size()
 	c, _ := child.Mask.Size()
 	return p <= c
+}
+
+func isPrivateCIDR(c *net.IPNet) bool {
+	for _, p := range privateCIDRs {
+		if isChildCIDR(p, c) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPublicCIDR(c *net.IPNet) bool {
+	for _, p := range privateCIDRs {
+		if isChildCIDR(c, p) {
+			return false
+		}
+	}
+	return true
 }
 
 func formatWithUnits(v int) string {

--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -73,7 +73,7 @@ func isPrivateCIDR(c *net.IPNet) bool {
 
 func isPublicCIDR(c *net.IPNet) bool {
 	for _, p := range privateCIDRs {
-		if isChildCIDR(c, p) {
+		if isChildCIDR(c, p) || isChildCIDR(p, c) {
 			return false
 		}
 	}

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -85,6 +85,10 @@ Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 				Args:     []string{"-l=test=self", "--with-cidrs=8.0.0.0/8"},
 				Expected: `Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 			},
+			{
+				Args:     []string{"-l=test=self", "--with-cidrs=0.0.0.0/0", "--unify-external"},
+				Expected: `Egress,public,cidr:public,false,false,17,53`,
+			},
 		}
 		for _, c := range cases {
 			args := append([]string{"traffic", "-o=json", "-n=test"}, c.Args...)


### PR DESCRIPTION
This PR adds `--unify-external` flag for `npv traffic` to merge cluster-external traffic into `private`, `public`, and `unknown`.

```
root@ubuntu-6cb57548bf-mtfkr:/# npv traffic -n test --unify-external 
DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
Egress    | 2        -         cidr:public                                    | UDP      53   |   744        8    93.0
                               ^^^^^^^^^^^
Egress    | 1899     test      l3-ingress-explicit-allow-all-854c9bb96c-sq5c5 | ANY      ANY  |  3880       48    80.8
Egress    | 6370     test      l4-ingress-explicit-allow-tcp-674bf84548-85c87 | TCP      8000 |  3880       48    80.8
Ingress   | 22657    test      self-7b54c7b648-xjd7d                          | ANY      ANY  |  3880       48    80.8
Ingress   | 22657    test      self-7b54c7b648-xjd7d                          | TCP      8000 |  3880       48    80.8
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
