### PR TITLE
add reserved:world to CIDR filter

### DIFF
--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -222,12 +222,17 @@ func makeCIDRFilter(ingress, egress bool, incl []*net.IPNet, excl []*net.IPNet) 
 		if (p.IsIngressRule() && !ingress) || (p.IsEgressRule() && !egress) {
 			return false, nil
 		}
-		if p.Key.Identity == 0 {
+
+		idObj := identity.NumericIdentity(p.Key.Identity)
+		switch idObj {
+		case identity.IdentityUnknown:
+		case identity.ReservedIdentityWorld:
+		case identity.ReservedIdentityWorldIPv4:
+		case identity.ReservedIdentityWorldIPv6:
 			return true, nil
 		}
 
 		// If the identity is not locally-scoped, it is not representing a CIDR
-		idObj := identity.NumericIdentity(p.Key.Identity)
 		if !idObj.HasLocalScope() {
 			return false, nil
 		}


### PR DESCRIPTION
`npv traffic --with-cidrs` missed traffic with `reserved:world` (unknown external IP).

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
