### PR TITLE
Fix CIDR filter

### DIFF
--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -225,10 +225,10 @@ func makeCIDRFilter(ingress, egress bool, incl []*net.IPNet, excl []*net.IPNet) 
 
 		idObj := identity.NumericIdentity(p.Key.Identity)
 		switch idObj {
-		case identity.IdentityUnknown:
-		case identity.ReservedIdentityWorld:
-		case identity.ReservedIdentityWorldIPv4:
-		case identity.ReservedIdentityWorldIPv6:
+		case identity.IdentityUnknown,
+			identity.ReservedIdentityWorld,
+			identity.ReservedIdentityWorldIPv4,
+			identity.ReservedIdentityWorldIPv6:
 			return true, nil
 		}
 

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -184,6 +184,11 @@ Allow,Ingress,reserved:host,false,false,6,8000
 Allow,Ingress,reserved:unknown,false,false,6,8000`,
 		},
 		{
+			Selector:  "test=l4-ingress-all-allow-tcp",
+			ExtraArgs: []string{"--with-cidrs=0.0.0.0/0"},
+			Expected:  `Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		{
 			ExtraArgs: []string{"--used"},
 			Expected: `Allow,Ingress,self,true,true,0,0
 Allow,Ingress,self,false,false,6,8000


### PR DESCRIPTION
This PR fixes a bug that omitted `reserved:unknown` and `reserved:world` from `npv inspect --with-cidrs <ANY CIDR>`.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
