### PR TITLE
Implement npv agent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ on:
 jobs:
   test:
     name: e2e
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: network-policy-viewer
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/cmd/npv/app/agent.go
+++ b/cmd/npv/app/agent.go
@@ -1,0 +1,13 @@
+package app
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(agentCmd)
+}
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Show cilium-agent name",
+	Long:  `Show cilium-agent name`,
+}

--- a/cmd/npv/app/agent_node.go
+++ b/cmd/npv/app/agent_node.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	agentCmd.AddCommand(agentNodeCmd)
+}
+
+var agentNodeCmd = &cobra.Command{
+	Use:   "node",
+	Short: "Show cilium-agent for a node",
+	Long:  `Show cilium-agent for a node`,
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAgentNode(context.Background(), cmd.OutOrStdout(), args[0])
+	},
+	ValidArgsFunction: completeNodes,
+}
+
+func runAgentNode(ctx context.Context, w io.Writer, node string) error {
+	clientset, _, err := createK8sClients()
+	if err != nil {
+		return err
+	}
+
+	if _, err = clientset.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{}); err != nil {
+		return fmt.Errorf("failed to get node %s: %w", node, err)
+	}
+
+	pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + node,
+		LabelSelector: "k8s-app=cilium",
+	})
+	if err != nil {
+		return err
+	}
+	if num := len(pods.Items); num != 1 {
+		return fmt.Errorf("failed to find cilium-agent. found %d pods", num)
+	}
+
+	fmt.Fprintln(w, pods.Items[0].Name)
+	return nil
+}

--- a/cmd/npv/app/agent_pod.go
+++ b/cmd/npv/app/agent_pod.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	agentCmd.AddCommand(agentPodCmd)
+}
+
+var agentPodCmd = &cobra.Command{
+	Use:   "pod",
+	Short: "Show cilium-agent for a pod",
+	Long:  `Show cilium-agent for a pod`,
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAgentPod(context.Background(), cmd.OutOrStdout(), args[0])
+	},
+	ValidArgsFunction: completePods,
+}
+
+func runAgentPod(ctx context.Context, w io.Writer, name string) error {
+	clientset, _, err := createK8sClients()
+	if err != nil {
+		return err
+	}
+
+	pod, err := clientset.CoreV1().Pods(rootOptions.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + pod.Spec.NodeName,
+		LabelSelector: "k8s-app=cilium",
+	})
+	if err != nil {
+		return err
+	}
+	if num := len(pods.Items); num != 1 {
+		return fmt.Errorf("failed to find cilium-agent. found %d pods", num)
+	}
+
+	fmt.Fprintln(w, pods.Items[0].Name)
+	return nil
+}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -19,8 +19,8 @@ help: ## Display this help
 
 .PHONY: wait-for-workloads
 wait-for-workloads:
-	kubectl wait --for=condition=Available --all deployments --all-namespaces --timeout=1h
-	kubectl wait --for=condition=Ready --all pods --all-namespaces --timeout=1h
+	kubectl wait --for=condition=Available --all deployments --all-namespaces --timeout=10m
+	kubectl wait --for=condition=Ready --all pods --all-namespaces --timeout=10m
 
 .PHONY: start
 start:
@@ -29,6 +29,7 @@ start:
 	kind load docker-image quay.io/cilium/cilium:v$(CILIUM_VERSION)
 	$(HELM) install cilium cilium/cilium --version $(CILIUM_VERSION) \
 		--namespace kube-system \
+		--set envoy.enabled=false \
 		--set image.pullPolicy=IfNotPresent \
 		--set ipam.mode=kubernetes
 

--- a/e2e/agent_test.go
+++ b/e2e/agent_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func testAgentNode() {
+	It("should show agent for nodes", func() {
+		data := kubectlSafe(Default, nil, "get", "node", "-o=jsonpath={.items[*].metadata.name}")
+		nodes := strings.Fields(string(data))
+
+		for _, node := range nodes {
+			expected := string(kubectlSafe(Default, nil, "get", "pod", "-n=kube-system", "-l=k8s-app=cilium", "--field-selector=spec.nodeName="+node, "-o=jsonpath={.items[*].metadata.name}"))
+			expected = strings.TrimSpace(expected)
+			actual := string(runViewerSafe(Default, nil, "agent", "node", node))
+			actual = strings.TrimSpace(actual)
+			Expect(actual).To(Equal(expected))
+		}
+	})
+}
+
+func testAgentPod() {
+	It("should show agent for pods", func() {
+		data := kubectlSafe(Default, nil, "get", "pod", "-n=test", "-o=jsonpath={.items[*].metadata.name}")
+		pods := strings.Fields(string(data))
+
+		for _, pod := range pods {
+			node := string(kubectlSafe(Default, nil, "get", "pod", "-n=test", pod, "-o=jsonpath={.spec.nodeName}"))
+			node = strings.TrimSpace(node)
+
+			expected := string(kubectlSafe(Default, nil, "get", "pod", "-n=kube-system", "-l=k8s-app=cilium", "--field-selector=spec.nodeName="+node, "-o=jsonpath={.items[*].metadata.name}"))
+			expected = strings.TrimSpace(expected)
+			actual := string(runViewerSafe(Default, nil, "agent", "pod", "-n=test", pod))
+			actual = strings.TrimSpace(actual)
+			Expect(actual).To(Equal(expected), "failed to show agent for pod %s", pod)
+		}
+	})
+}

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -43,6 +43,8 @@ func processTestTraffic() {
 }
 
 func runTest() {
+	Context("agent-node", testAgentNode)
+	Context("agent-pod", testAgentPod)
 	Context("dump", testDump)
 	Context("list", testList)
 	Context("list-all", testListAll)

--- a/e2e/testdata/ubuntu.yaml
+++ b/e2e/testdata/ubuntu.yaml
@@ -64,4 +64,4 @@ spec:
         - name: ubuntu
           args:
             - pause
-          image: ghcr.io/cybozu/ubuntu-debug:24.04
+          image: ghcr.io/cybozu/ubuntu:24.04


### PR DESCRIPTION
This PR adds the following commands.
- `npv agent node <NODE>`: show cilium-agent for the specified node
- `npv agent pod -n <NAMESPACE> <POD>`: show cilium-agent for the specified pod

```
$ npv agent node kind-worker
cilium-mnc5l

$ npv agent pod -n test l3-ingress-explicit-allow-all-774f768dc8-pvwpk 
cilium-mnc5l
```

Note:
I've upgraded CI to use GitHub-hosted larger runner to increase storage capacity.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
