### PR TITLE
Modify npv list to show applied network policies for each pod

### DIFF
--- a/cmd/npv/app/helper_k8s.go
+++ b/cmd/npv/app/helper_k8s.go
@@ -92,6 +92,14 @@ func getSubjectNamespace() string {
 	return rootOptions.namespace
 }
 
+func getPodSubject(pod *corev1.Pod) string {
+	if rootOptions.allNamespaces {
+		return pod.Namespace + "/" + pod.Name
+	} else {
+		return pod.Name
+	}
+}
+
 func selectSubjectPods(ctx context.Context, clientset *kubernetes.Clientset, name, selector string) ([]*corev1.Pod, error) {
 	if (name != "") && (rootOptions.allNamespaces || selector != "") {
 		return nil, errors.New("multiple pods should not be selected when pod name is specified")

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -134,11 +134,7 @@ func runInspectOnPod(ctx context.Context, clientset *kubernetes.Clientset, dynam
 	arr := make([]inspectEntry, len(policies))
 	for i, p := range policies {
 		var entry inspectEntry
-		if rootOptions.allNamespaces {
-			entry.Subject = pod.Namespace + "/" + pod.Name
-		} else {
-			entry.Subject = pod.Name
-		}
+		entry.Subject = getPodSubject(pod)
 		if p.IsDeny() {
 			entry.Policy = policyDeny
 		} else {

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -210,9 +210,7 @@ Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000`,
 			}
 			args = append(args, c.ExtraArgs...)
 			result := runViewerSafe(Default, nil, args...)
-			// remove hash suffix from pod names
-			result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | split("-") | .[0:5] | join("-"))]`)
-			result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | if startswith("self") then "self" else . end)]`)
+			result = fixJsonPodField(Default, result, "example_endpoint")
 			result = jqSafe(Default, result, "-r", `.[] | [.policy, .direction, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port] | @csv`)
 			resultString := strings.Replace(string(result), `"`, "", -1)
 			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nargs: %v\nactual: %s\nexpected: %s", c.Selector, c.ExtraArgs, resultString, c.Expected)

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -101,24 +101,21 @@ Ingress,CiliumNetworkPolicy,test,l4-ingress-all-allow-tcp`,
 	})
 }
 
-func testListAll() {
-	expected := `Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
-Egress,CiliumNetworkPolicy,test,l3-self
-Egress,CiliumNetworkPolicy,test,l4-self
-Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
-Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-allow-all
-Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-deny-all
-Ingress,CiliumNetworkPolicy,test,l3-self
-Ingress,CiliumNetworkPolicy,test,l4-ingress-all-allow-tcp
-Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-allow-any
-Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-allow-tcp
-Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-deny-any
-Ingress,CiliumNetworkPolicy,test,l4-ingress-explicit-deny-udp
-Ingress,CiliumNetworkPolicy,test,l4-self`
+func testListWithSelector() {
+	expected := `l3-ingress-explicit-allow-all,Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-allow-all,Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-allow-all,Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-allow-all
+l3-ingress-explicit-allow-all,Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-allow-all,Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-allow-all,Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-allow-all
+l3-ingress-explicit-deny-all,Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-deny-all,Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-deny-all,Ingress,CiliumNetworkPolicy,test,l3-ingress-explicit-deny-all`
 
 	It("should list applied policies for multiple pods", func() {
-		result := runViewerSafe(Default, nil, "list", "-o=json", "-n=test")
-		result = jqSafe(Default, result, "-r", ".[] | [.direction, .kind, .namespace, .name] | @csv")
+		result := runViewerSafe(Default, nil, "list", "-o=json", "-n=test", "-l=test in (l3-ingress-explicit-allow-all,l3-ingress-explicit-deny-all)")
+		result = fixJsonPodField(Default, result, "subject")
+		result = jqSafe(Default, result, "-r", ".[] | [.subject, .direction, .kind, .namespace, .name] | @csv")
 		resultString := strings.Replace(string(result), `"`, "", -1)
 		Expect(resultString).To(Equal(expected), "compare failed. actual: %s\nexpected: %s", resultString, expected)
 	})

--- a/e2e/manifest_test.go
+++ b/e2e/manifest_test.go
@@ -139,9 +139,7 @@ To,test,l3-ingress-explicit-allow-all`
 		from := "--from=test/" + onePodByLabelSelector(Default, "test", "test=self")
 		to := "--to=test/" + onePodByLabelSelector(Default, "test", "test=l3-ingress-explicit-allow-all")
 		result := runViewerSafe(Default, nil, "manifest", "range", from, to, "-o=json")
-		// remove hash suffix from pod names
-		result = jqSafe(Default, result, "-r", `[.[] | .name = (.name | split("-") | .[0:5] | join("-"))]`)
-		result = jqSafe(Default, result, "-r", `[.[] | .name = (.name | if startswith("self") then "self" else . end)]`)
+		result = fixJsonPodField(Default, result, "name")
 		result = jqSafe(Default, result, "-r", `.[] | [.part, .namespace, .name] | @csv`)
 		resultString := strings.Replace(string(result), `"`, "", -1)
 		Expect(resultString).To(Equal(expected), "compare failed.\nactual: %s\nexpected: %s", resultString, expected)

--- a/e2e/reach_test.go
+++ b/e2e/reach_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func formatReachResult(result []byte) string {
-	// remove hash suffix from pod names
-	result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | split("-") | .[0:5] | join("-"))]`)
-	result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | if startswith("self") then "self" else . end)]`)
+	result = fixJsonPodField(Default, result, "example_endpoint")
 	// "npv reach" returns a unstable result, so we need to sort it in test
 	result = jqSafe(Default, result, "-r", `sort_by(.role, .direction, .policy, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port)`)
 	result = jqSafe(Default, result, "-r", `.[] | [.role, .direction, .policy, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port] | @csv`)

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -47,7 +47,7 @@ func runTest() {
 	Context("agent-pod", testAgentPod)
 	Context("dump", testDump)
 	Context("list", testList)
-	Context("list-all", testListAll)
+	Context("list-with-selector", testListWithSelector)
 	Context("list-manifests", testListManifests)
 	Context("id-label", testIdLabel)
 	Context("id-summary", testIdSummary)

--- a/e2e/summary_test.go
+++ b/e2e/summary_test.go
@@ -26,9 +26,7 @@ self,2,1,17,8`
 
 	It("should show summary", func() {
 		result := runViewerSafe(Default, nil, "summary", "-o=json", "-n=test")
-		// remove hash suffix from pod names
-		result = jqSafe(Default, result, "-r", `[.[] | .name = (.name | split("-") | .[0:5] | join("-"))]`)
-		result = jqSafe(Default, result, "-r", `[.[] | .name = (.name | if startswith("self") then "self" else . end)]`)
+		result = fixJsonPodField(Default, result, "name")
 		result = jqSafe(Default, result, "-r", `.[] | [.name, .ingress_allow, .ingress_deny, .egress_allow, .egress_deny] | @csv`)
 		resultString := strings.Replace(string(result), `"`, "", -1)
 		Expect(resultString).To(Equal(expected), "compare failed.\nactual: %s\nexpected: %s", resultString, expected)

--- a/e2e/testdata/ubuntu.yaml
+++ b/e2e/testdata/ubuntu.yaml
@@ -64,4 +64,5 @@ spec:
         - name: ubuntu
           args:
             - pause
-          image: ghcr.io/cybozu/ubuntu:24.04
+          # ubuntu-debug is necessary to use bash completion
+          image: ghcr.io/cybozu/ubuntu-debug:24.04

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func formatTrafficResult(result []byte, amount bool) string {
-	// remove hash suffix from pod names
-	result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | split("-") | .[0:5] | join("-"))]`)
-	result = jqSafe(Default, result, "-r", `[.[] | .example_endpoint = (.example_endpoint | if startswith("self") then "self" else . end)]`)
+	result = fixJsonPodField(Default, result, "example_endpoint")
 	result = jqSafe(Default, result, "-r", `sort_by(.direction, .cidr, .example_endpoint, .wildcard_protocol, .wildcard_port, .protocol, .port)`)
 	if amount {
 		result = jqSafe(Default, result, "-r", `.[] | [.example_endpoint, .bytes] | @csv`)

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -68,6 +68,13 @@ func onePodByLabelSelector(g Gomega, namespace, selector string) string {
 	return string(jqSafe(g, data, "-r", ".items[0].metadata.name"))
 }
 
+func fixJsonPodField(g Gomega, input []byte, field string) []byte {
+	// remove hash suffix from pod names
+	input = jqSafe(g, input, "-r", fmt.Sprintf(`[.[] | .%s = (.%s | split("-") | .[0:5] | join("-"))]`, field, field))
+	input = jqSafe(g, input, "-r", fmt.Sprintf(`[.[] | .%s = (.%s | if startswith("self") then "self" else . end)]`, field, field))
+	return input
+}
+
 func makeIntersection(x, y []string) []string {
 	ret := make([]string, 0)
 	mx := make(map[string]any)


### PR DESCRIPTION
This PR makes `npv list` to show applied network policies for multiple pods.

### Former Output

Strictly speaking it already can - but the information, who is applied which policy, was omitted.
This generated a rather confusing output.

```
$ npv list -n test '-l=test in (l3-ingress-explicit-allow-all,l3-ingress-explicit-deny-all)'
DIRECTION KIND                           NAMESPACE NAME
Egress    CiliumClusterwideNetworkPolicy -         l3-baseline
Ingress   CiliumClusterwideNetworkPolicy -         l3-baseline
Ingress   CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
Ingress   CiliumNetworkPolicy            test      l3-ingress-explicit-deny-all
```

### Updated Output
Now it yields a separate list for each pod.
This is easier to understand than the previous one.

```
$ npv list -n test '-l=test in (l3-ingress-explicit-allow-all,l3-ingress-explicit-deny-all)'
SUBJECT                                        | DIRECTION KIND                           NAMESPACE NAME
l3-ingress-explicit-allow-all-774f768dc8-f8fsg | Egress    CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-allow-all-774f768dc8-f8fsg | Ingress   CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-allow-all-774f768dc8-f8fsg | Ingress   CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
l3-ingress-explicit-allow-all-774f768dc8-t9swz | Egress    CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-allow-all-774f768dc8-t9swz | Ingress   CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-allow-all-774f768dc8-t9swz | Ingress   CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
l3-ingress-explicit-deny-all-6dd976fcbc-lwczq  | Egress    CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-deny-all-6dd976fcbc-lwczq  | Ingress   CiliumClusterwideNetworkPolicy -         l3-baseline
l3-ingress-explicit-deny-all-6dd976fcbc-lwczq  | Ingress   CiliumNetworkPolicy            test      l3-ingress-explicit-deny-all
```
Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
