### PR TITLE
Add --ingress and --egress options to list command

### DIFF
--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -19,8 +19,6 @@ import (
 )
 
 var inspectOptions struct {
-	ingress bool
-	egress  bool
 	allowed bool
 	denied  bool
 	used    bool
@@ -28,14 +26,13 @@ var inspectOptions struct {
 }
 
 func init() {
-	inspectCmd.Flags().BoolVar(&inspectOptions.ingress, "ingress", false, "show ingress-rules only")
-	inspectCmd.Flags().BoolVar(&inspectOptions.egress, "egress", false, "show egress-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.allowed, "allowed", false, "show allowed-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.denied, "denied", false, "show denied-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.used, "used", false, "show used-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.unused, "unused", false, "show unused-rules only")
 	addSelectorOption(inspectCmd)
 	addWithCIDROptions(inspectCmd)
+	addDirectionOption(inspectCmd)
 	rootCmd.AddCommand(inspectCmd)
 }
 
@@ -98,10 +95,6 @@ func lessInspectEntry(x, y *inspectEntry) bool {
 }
 
 func parseInspectOptions() {
-	if !inspectOptions.ingress && !inspectOptions.egress {
-		inspectOptions.ingress = true
-		inspectOptions.egress = true
-	}
 	if !inspectOptions.allowed && !inspectOptions.denied {
 		inspectOptions.allowed = true
 		inspectOptions.denied = true
@@ -195,7 +188,7 @@ func runInspectOnPod(ctx context.Context, clientset *kubernetes.Clientset, dynam
 func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	parseInspectOptions()
 	basicFilter := makeBasicFilter(
-		inspectOptions.ingress, inspectOptions.egress,
+		policyOptions.ingress, policyOptions.egress,
 		inspectOptions.allowed, inspectOptions.denied,
 		inspectOptions.used, inspectOptions.unused,
 	)

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -27,6 +27,7 @@ var listOptions struct {
 
 func init() {
 	addSelectorOption(listCmd)
+	addDirectionOption(listCmd)
 	listCmd.Flags().BoolVarP(&listOptions.manifests, "manifests", "m", false, "show policy manifests")
 	rootCmd.AddCommand(listCmd)
 }
@@ -122,19 +123,22 @@ func runListOnPod(ctx context.Context, clientset *kubernetes.Clientset, dynamicC
 		return nil, errors.New("api response is insufficient")
 	}
 
-	ingressRules := response.Payload.Status.Policy.Realized.L4.Ingress
-	for _, rule := range ingressRules {
-		for _, r := range rule.DerivedFromRules {
-			entry := parseDerivedFromEntry(getPodSubject(pod), directionIngress, r)
-			policySet[entry] = struct{}{}
+	if policyOptions.ingress {
+		ingressRules := response.Payload.Status.Policy.Realized.L4.Ingress
+		for _, rule := range ingressRules {
+			for _, r := range rule.DerivedFromRules {
+				entry := parseDerivedFromEntry(getPodSubject(pod), directionIngress, r)
+				policySet[entry] = struct{}{}
+			}
 		}
 	}
-
-	egressRules := response.Payload.Status.Policy.Realized.L4.Egress
-	for _, rule := range egressRules {
-		for _, r := range rule.DerivedFromRules {
-			entry := parseDerivedFromEntry(getPodSubject(pod), directionEgress, r)
-			policySet[entry] = struct{}{}
+	if policyOptions.egress {
+		egressRules := response.Payload.Status.Policy.Realized.L4.Egress
+		for _, rule := range egressRules {
+			for _, r := range rule.DerivedFromRules {
+				entry := parseDerivedFromEntry(getPodSubject(pod), directionEgress, r)
+				policySet[entry] = struct{}{}
+			}
 		}
 	}
 
@@ -178,14 +182,14 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	}
 
 	subHeader := []string{"SUBJECT", "|"}
-	header := []string{"DIRECTION", "KIND", "NAMESPACE", "NAME"}
+	header := []string{"DIRECTION", "|", "KIND", "NAMESPACE", "NAME"}
 	if name == "" {
 		header = append(subHeader, header...)
 	}
 	return writeSimpleOrJson(stdout, policyList, header, len(policyList), func(index int) []any {
 		p := policyList[index]
 		subValues := []any{p.Subject, "|"}
-		values := []any{p.Direction, p.Kind, p.Namespace, p.Name}
+		values := []any{p.Direction, "|", p.Kind, p.Namespace, p.Name}
 		if name == "" {
 			values = append(subValues, values...)
 		}

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -77,6 +77,18 @@ var commonOptions struct {
 	with     cidrOptions
 }
 
+var policyOptions struct {
+	ingress bool
+	egress  bool
+}
+
+func fillPolicyOptions() {
+	if !policyOptions.ingress && !policyOptions.egress {
+		policyOptions.ingress = true
+		policyOptions.egress = true
+	}
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringP(flagNamespace, "n", "default", "namespace of pods")
 	rootCmd.PersistentFlags().BoolP(flagAllNamespaces, "A", false, "show pods across all namespaces")
@@ -99,6 +111,11 @@ func init() {
 
 func addSelectorOption(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&commonOptions.selector, "selector", "l", "", "specify label constraints")
+}
+
+func addDirectionOption(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&policyOptions.ingress, "ingress", false, "show ingress-rules only")
+	cmd.Flags().BoolVar(&policyOptions.egress, "egress", false, "show egress-rules only")
 }
 
 func addWithCIDROptions(cmd *cobra.Command) {
@@ -139,7 +156,11 @@ func parseCIDROptions(ingress, egress bool, prefix string, opts *cidrOptions) (p
 var rootCmd = &cobra.Command{
 	Use: "npv",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return fillRootOptions(cmd)
+		if err := fillRootOptions(cmd); err != nil {
+			return err
+		}
+		fillPolicyOptions()
+		return nil
 	},
 }
 

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -20,16 +20,13 @@ import (
 )
 
 var trafficOptions struct {
-	ingress       bool
-	egress        bool
 	unifyExternal bool
 }
 
 func init() {
 	addSelectorOption(trafficCmd)
 	addWithCIDROptions(trafficCmd)
-	trafficCmd.Flags().BoolVar(&trafficOptions.ingress, "ingress", false, "show ingress-rules only")
-	trafficCmd.Flags().BoolVar(&trafficOptions.egress, "egress", false, "show egress-rules only")
+	addDirectionOption(trafficCmd)
 	trafficCmd.Flags().BoolVar(&trafficOptions.unifyExternal, "unify-external", false, "unify cluster-external traffic into public, private, and unknown")
 	rootCmd.AddCommand(trafficCmd)
 }
@@ -84,13 +81,6 @@ func lessTrafficEntry(x, y *trafficEntry) bool {
 		ret = strings.Compare(x.CIDR, y.CIDR)
 	}
 	return ret < 0
-}
-
-func parseTrafficOptions() {
-	if !trafficOptions.ingress && !trafficOptions.egress {
-		trafficOptions.ingress = true
-		trafficOptions.egress = true
-	}
 }
 
 func runTrafficOnPod(ctx context.Context, clientset *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, filter policyFilter, pod *corev1.Pod) (map[trafficKey]*trafficValue, error) {
@@ -203,9 +193,8 @@ func runTrafficOnPod(ctx context.Context, clientset *kubernetes.Clientset, dynam
 }
 
 func runTraffic(ctx context.Context, stdout, stderr io.Writer, name string) error {
-	parseTrafficOptions()
 	basicFilter := makeBasicFilter(
-		trafficOptions.ingress, trafficOptions.egress,
+		policyOptions.ingress, policyOptions.egress,
 		true,  // allowed
 		false, // denied
 		true,  // used

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -96,24 +96,6 @@ Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,132,53`,
 		},
 		{
-			Selector:  "test=self",
-			ExtraArgs: []string{"--allowed", "--ingress"},
-			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
-Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector:  "test=self",
-			ExtraArgs: []string{"--denied", "--egress"},
-			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
-Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
-Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
-Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
-Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
-Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
-Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
-		},
-		{
 			Selector:  "test=l4-ingress-explicit-allow-tcp",
 			ExtraArgs: []string{"--used"},
 			Expected:  `Allow,Ingress,self,false,false,6,8000`,
@@ -198,6 +180,26 @@ Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
 Allow,Egress,l3-ingress-explicit-allow-all,true,true,0,0
 Allow,Egress,l4-ingress-explicit-allow-tcp,false,false,6,8000`,
+		},
+		// npv inspect should handle --ingress and --egress
+		// npv inspect should handle --allowed and --denied
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--ingress", "--allowed"},
+			Expected: `Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
+Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--egress", "--denied"},
+			Expected: `Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Deny,Egress,l3-egress-explicit-deny-all,true,true,0,0
+Deny,Egress,l4-egress-explicit-deny-any,false,false,6,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,17,53
+Deny,Egress,l4-egress-explicit-deny-any,false,false,132,53
+Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
 		},
 	}
 

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -9,9 +9,11 @@ import (
 
 func testList() {
 	cases := []struct {
-		Selector string
-		Expected string
+		Selector  string
+		ExtraArgs []string
+		Expected  string
 	}{
+		// npv list should show correct result for each pod
 		{
 			Selector: "test=self",
 			Expected: `Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
@@ -88,12 +90,29 @@ Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline`,
 Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
 Ingress,CiliumNetworkPolicy,test,l4-ingress-all-allow-tcp`,
 		},
+		// npv list should handle --ingress and --egress
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--ingress"},
+			Expected: `Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+Ingress,CiliumNetworkPolicy,test,l3-self
+Ingress,CiliumNetworkPolicy,test,l4-self`,
+		},
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--egress"},
+			Expected: `Egress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+Egress,CiliumNetworkPolicy,test,l3-self
+Egress,CiliumNetworkPolicy,test,l4-self`,
+		},
 	}
 
 	It("should list applied policies", func() {
 		for _, c := range cases {
 			podName := onePodByLabelSelector(Default, "test", c.Selector)
-			result := runViewerSafe(Default, nil, "list", "-o=json", "-n=test", podName)
+			args := []string{"list", "-o=json", "-n=test", podName}
+			args = append(args, c.ExtraArgs...)
+			result := runViewerSafe(Default, nil, args...)
 			result = jqSafe(Default, result, "-r", ".[] | [.direction, .kind, .namespace, .name] | @csv")
 			resultString := strings.Replace(string(result), `"`, "", -1)
 			Expect(resultString).To(Equal(c.Expected), "compare failed. selector: %s\nactual: %s\nexpected: %s", c.Selector, resultString, c.Expected)

--- a/e2e/traffic_test.go
+++ b/e2e/traffic_test.go
@@ -87,17 +87,18 @@ Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
 				Args:     []string{"-l=test=self", "--with-cidrs=0.0.0.0/0", "--unify-external"},
 				Expected: `Egress,public,cidr:public,false,false,17,53`,
 			},
+			// npv traffic should handle --ingress and --egress
+			{
+				Args: []string{"--ingress"},
+				Expected: `Ingress,,self,false,false,6,8000
+Ingress,,self,true,true,0,0`,
+			},
 			{
 				Args: []string{"--egress"},
 				Expected: `Egress,,l3-ingress-explicit-allow-all,true,true,0,0
 Egress,,l4-ingress-explicit-allow-tcp,false,false,6,8000
 Egress,1.1.1.1/32,cidr:1.1.1.1/32,false,false,17,53
 Egress,8.8.8.8/32,cidr:8.8.8.8/32,false,false,17,53`,
-			},
-			{
-				Args: []string{"--ingress"},
-				Expected: `Ingress,,self,false,false,6,8000
-Ingress,,self,true,true,0,0`,
 			},
 		}
 		for _, c := range cases {


### PR DESCRIPTION
This PR adds `--ingress` and `--egress` options to `npv list`, enabling it to show CCNPs/CNPs relevant to a pod's ingress or egress traffic.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
