### PR TITLE
Fetch all local CIDR identities at once

### DIFF
--- a/cmd/cilium-agent-proxy/app/run.go
+++ b/cmd/cilium-agent-proxy/app/run.go
@@ -39,6 +39,7 @@ func handleEndpoint(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r.URL.Path, "failed to call Cilium API", http.StatusInternalServerError)
 		return
 	}
+	defer resp.Body.Close()
 
 	buf := new(bytes.Buffer)
 	io.Copy(buf, resp.Body)
@@ -52,6 +53,7 @@ func handleCIDRIdentities(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r.URL.Path, "failed to call Cilium API", http.StatusInternalServerError)
 		return
 	}
+	defer resp.Body.Close()
 
 	// https://github.com/cilium/cilium/blob/main/api/v1/models/identity.go
 	type Identity struct {

--- a/cmd/cilium-agent-proxy/app/run.go
+++ b/cmd/cilium-agent-proxy/app/run.go
@@ -45,7 +45,7 @@ func handleEndpoint(w http.ResponseWriter, r *http.Request) {
 	renderJSON(w, r.URL.Path, buf.Bytes(), http.StatusOK)
 }
 
-func handleCIDRIdentites(w http.ResponseWriter, r *http.Request) {
+func handleCIDRIdentities(w http.ResponseWriter, r *http.Request) {
 	url := "http://localhost/v1/identity"
 	resp, err := socketClient.Get(url)
 	if err != nil {
@@ -164,7 +164,7 @@ func subMain() error {
 	}
 
 	http.HandleFunc("/v1/endpoint/", handleEndpoint)
-	http.HandleFunc("/cidr-identities", handleCIDRIdentites)
+	http.HandleFunc("/cidr-identities", handleCIDRIdentities)
 	http.HandleFunc("/policy/", handlePolicy)
 	http.HandleFunc("/version", handleVersion)
 

--- a/cmd/cilium-agent-proxy/app/run.go
+++ b/cmd/cilium-agent-proxy/app/run.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
+	"strings"
 )
 
 const socketPath = "/var/run/cilium/cilium.sock"
@@ -43,30 +45,47 @@ func handleEndpoint(w http.ResponseWriter, r *http.Request) {
 	renderJSON(w, r.URL.Path, buf.Bytes(), http.StatusOK)
 }
 
-func handleIdentity(w http.ResponseWriter, r *http.Request) {
-	param := r.URL.Path[len("/v1/identity/"):]
-	if len(param) == 0 {
-		renderError(w, r.URL.Path, "failed to read identity", http.StatusBadRequest)
-		return
-	}
-
-	// Convert to number to avoid parameter injection
-	identity, err := strconv.Atoi(param)
-	if err != nil {
-		renderError(w, r.URL.Path, "failed to read identity", http.StatusBadRequest)
-		return
-	}
-
-	url := fmt.Sprintf("http://localhost/v1/identity/%d", identity)
+func handleCIDRIdentites(w http.ResponseWriter, r *http.Request) {
+	url := "http://localhost/v1/identity"
 	resp, err := socketClient.Get(url)
 	if err != nil {
 		renderError(w, r.URL.Path, "failed to call Cilium API", http.StatusInternalServerError)
 		return
 	}
 
-	buf := new(bytes.Buffer)
-	io.Copy(buf, resp.Body)
-	renderJSON(w, r.URL.Path, buf.Bytes(), http.StatusOK)
+	// https://github.com/cilium/cilium/blob/main/api/v1/models/identity.go
+	type Identity struct {
+		ID     int64    `json:"id,omitempty"`
+		Labels []string `json:"labels,omitempty"`
+	}
+	var ids []Identity
+	{
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			renderError(w, r.URL.Path, "failed to read data", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(data, &ids); err != nil {
+			renderError(w, r.URL.Path, "failed to unmarshal result", http.StatusInternalServerError)
+			return
+		}
+	}
+	ids = slices.DeleteFunc(ids, func(i Identity) bool {
+		// https://docs.cilium.io/en/stable/internals/security-identities/
+		if (1<<24) <= i.ID && i.ID < (1<<25) {
+			return !slices.ContainsFunc(i.Labels, func(l string) bool {
+				return strings.HasPrefix(l, "cidr:")
+			})
+		}
+		return true
+	})
+
+	data, err := json.Marshal(ids)
+	if err != nil {
+		renderError(w, r.URL.Path, "failed to marshal result", http.StatusInternalServerError)
+		return
+	}
+	renderJSON(w, r.URL.Path, data, http.StatusOK)
 }
 
 func handlePolicy(w http.ResponseWriter, r *http.Request) {
@@ -145,7 +164,7 @@ func subMain() error {
 	}
 
 	http.HandleFunc("/v1/endpoint/", handleEndpoint)
-	http.HandleFunc("/v1/identity/", handleIdentity)
+	http.HandleFunc("/cidr-identities", handleCIDRIdentites)
 	http.HandleFunc("/policy/", handlePolicy)
 	http.HandleFunc("/version", handleVersion)
 

--- a/cmd/npv/app/dump.go
+++ b/cmd/npv/app/dump.go
@@ -43,11 +43,18 @@ func runDump(ctx context.Context, w io.Writer, name string) error {
 		return err
 	}
 
-	resp, err := http.Get(proxyEndpoint + fmt.Sprintf("/v1/endpoint/%d", endpointID))
+	url := proxyEndpoint + fmt.Sprintf("/v1/endpoint/%d", endpointID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -26,17 +25,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type cachedIdentity struct {
-	identity *models.Identity
-	cidr     *net.IPNet
-}
-
 type proxyClient struct {
 	*client.Client
 
-	node                 string
-	endpointURL          string
-	cachedCIDRIdentities map[uint32]*cachedIdentity
+	node                string
+	endpointURL         string
+	cachedIdentityCIDRs map[uint32]*net.IPNet
 }
 
 var (
@@ -111,14 +105,25 @@ func createCiliumClient(ctx context.Context, stderr io.Writer, c *kubernetes.Cli
 
 func (c *proxyClient) testAgentVersion(ctx context.Context, stderr io.Writer) error {
 	url := c.endpointURL + "/version"
-	resp, err := http.Get(url)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to request version: %w", err)
 	}
 	defer resp.Body.Close()
+
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(data))
 	}
 
 	var result struct {
@@ -137,19 +142,30 @@ func (c *proxyClient) testAgentVersion(ctx context.Context, stderr io.Writer) er
 	return nil
 }
 
-func (c *proxyClient) fetchCIDRIdentities() error {
-	if c.cachedCIDRIdentities != nil {
+func (c *proxyClient) fetchCIDRIdentities(ctx context.Context) error {
+	if c.cachedIdentityCIDRs != nil {
 		return nil
 	}
 
 	url := c.endpointURL + "/cidr-identities"
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to request /cidr-identities: %w", err)
 	}
+	defer resp.Body.Close()
+
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read /cidr-identities: %w", err)
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(data))
 	}
 
 	var m []models.Identity
@@ -157,7 +173,7 @@ func (c *proxyClient) fetchCIDRIdentities() error {
 		return fmt.Errorf("failed to unmarshal /cidr-identities: %w", err)
 	}
 
-	c.cachedCIDRIdentities = make(map[uint32]*cachedIdentity)
+	c.cachedIdentityCIDRs = make(map[uint32]*net.IPNet)
 	for _, id := range m {
 		lbls := labels.NewLabelsFromModel(id.Labels)
 		cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
@@ -173,24 +189,21 @@ func (c *proxyClient) fetchCIDRIdentities() error {
 			return fmt.Errorf("failed to parse CIDR for identity %d", id.ID)
 		}
 
-		c.cachedCIDRIdentities[uint32(id.ID)] = &cachedIdentity{
-			identity: &id,
-			cidr:     cidr,
-		}
+		c.cachedIdentityCIDRs[uint32(id.ID)] = cidr
 	}
 	return nil
 }
 
-func (c *proxyClient) getCIDRIdentity(ctx context.Context, id uint32) (*models.Identity, error) {
-	if err := c.fetchCIDRIdentities(); err != nil {
+func (c *proxyClient) getCIDRForIdentity(ctx context.Context, id uint32) (*net.IPNet, error) {
+	if err := c.fetchCIDRIdentities(ctx); err != nil {
 		return nil, err
 	}
 
-	value, ok := c.cachedCIDRIdentities[id]
+	value, ok := c.cachedIdentityCIDRs[id]
 	if !ok {
 		return nil, fmt.Errorf("failed to find CIDR identity for %d", id)
 	}
-	return value.identity, nil
+	return value, nil
 }
 
 // For the meanings of the flags, see:
@@ -235,7 +248,12 @@ func queryPolicyMap(ctx context.Context, clientset *kubernetes.Clientset, dynami
 	}
 
 	url = fmt.Sprintf("%s/policy/%d", url, endpointID)
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request policy: %w", err)
 	}
@@ -326,21 +344,7 @@ func makeCIDRFilter(ingress, egress bool, incl []*net.IPNet, excl []*net.IPNet) 
 		}
 
 		// Retrieve identity information
-		cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
-		if err != nil {
-			return false, err
-		}
-		if !slices.Contains(cidrID.Labels, "reserved:world") {
-			return false, nil
-		}
-
-		// Compute leaf CIDR of the identity
-		lbls := labels.NewLabelsFromModel(cidrID.Labels)
-		cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
-		if len(cidrModel) != 1 {
-			return false, errors.New("internal error")
-		}
-		_, idCIDR, err := net.ParseCIDR(strings.Split(cidrModel[0], ":")[1])
+		idCIDR, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
 		if err != nil {
 			return false, err
 		}

--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -188,7 +188,7 @@ func (c *proxyClient) getCIDRIdentity(ctx context.Context, id uint32) (*models.I
 
 	value, ok := c.cachedCIDRIdentities[id]
 	if !ok {
-		return nil, fmt.Errorf("failed to found CIDR identity for %d", id)
+		return nil, fmt.Errorf("failed to find CIDR identity for %d", id)
 	}
 	return value.identity, nil
 }

--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -9,11 +9,10 @@ import (
 	"net"
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
-	"github.com/cilium/cilium/api/v1/client/policy"
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
@@ -27,12 +26,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type cachedIdentity struct {
+	identity *models.Identity
+	cidr     *net.IPNet
+}
+
 type proxyClient struct {
 	*client.Client
 
-	node                string
-	endpointURL         string
-	cachedLocalIdentity map[uint32]*policy.GetIdentityIDOK
+	node                 string
+	endpointURL          string
+	cachedCIDRIdentities map[uint32]*cachedIdentity
 }
 
 var (
@@ -105,29 +109,6 @@ func createCiliumClient(ctx context.Context, stderr io.Writer, c *kubernetes.Cli
 	return proxy, nil
 }
 
-func (c *proxyClient) queryLocalIdentity(ctx context.Context, id uint32) (*policy.GetIdentityIDOK, error) {
-	if c.cachedLocalIdentity == nil {
-		c.cachedLocalIdentity = make(map[uint32]*policy.GetIdentityIDOK)
-	}
-
-	if _, ok := c.cachedLocalIdentity[id]; !ok {
-		// If the identity is in the local scope, it is only valid on the reporting node.
-		params := policy.GetIdentityIDParams{
-			Context: ctx,
-			ID:      strconv.FormatInt(int64(id), 10),
-		}
-		response, err := c.Policy.GetIdentityID(&params)
-		switch err {
-		case nil:
-			c.cachedLocalIdentity[id] = response
-		default:
-			err = fmt.Errorf("failed to get identity: %w", err)
-		}
-		return response, err
-	}
-	return c.cachedLocalIdentity[id], nil
-}
-
 func (c *proxyClient) testAgentVersion(ctx context.Context, stderr io.Writer) error {
 	url := c.endpointURL + "/version"
 	resp, err := http.Get(url)
@@ -154,6 +135,62 @@ func (c *proxyClient) testAgentVersion(ctx context.Context, stderr io.Writer) er
 	}
 
 	return nil
+}
+
+func (c *proxyClient) fetchCIDRIdentities() error {
+	if c.cachedCIDRIdentities != nil {
+		return nil
+	}
+
+	url := c.endpointURL + "/cidr-identities"
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to request /cidr-identities: %w", err)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read /cidr-identities: %w", err)
+	}
+
+	var m []models.Identity
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("failed to unmarshal /cidr-identities: %w", err)
+	}
+
+	c.cachedCIDRIdentities = make(map[uint32]*cachedIdentity)
+	for _, id := range m {
+		lbls := labels.NewLabelsFromModel(id.Labels)
+		cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
+		if len(cidrModel) != 1 {
+			return fmt.Errorf("unexpected CIDR label for identity %d", id.ID)
+		}
+		parts := strings.Split(cidrModel[0], ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("failed to parse CIDR label for identity %d", id.ID)
+		}
+		_, cidr, err := net.ParseCIDR(parts[1])
+		if err != nil {
+			return fmt.Errorf("failed to parse CIDR for identity %d", id.ID)
+		}
+
+		c.cachedCIDRIdentities[uint32(id.ID)] = &cachedIdentity{
+			identity: &id,
+			cidr:     cidr,
+		}
+	}
+	return nil
+}
+
+func (c *proxyClient) getCIDRIdentity(ctx context.Context, id uint32) (*models.Identity, error) {
+	if err := c.fetchCIDRIdentities(); err != nil {
+		return nil, err
+	}
+
+	value, ok := c.cachedCIDRIdentities[id]
+	if !ok {
+		return nil, fmt.Errorf("failed to found CIDR identity for %d", id)
+	}
+	return value.identity, nil
 }
 
 // For the meanings of the flags, see:
@@ -289,16 +326,16 @@ func makeCIDRFilter(ingress, egress bool, incl []*net.IPNet, excl []*net.IPNet) 
 		}
 
 		// Retrieve identity information
-		response, err := client.queryLocalIdentity(ctx, p.Key.Identity)
+		cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
 		if err != nil {
 			return false, err
 		}
-		if !slices.Contains(response.Payload.Labels, "reserved:world") {
+		if !slices.Contains(cidrID.Labels, "reserved:world") {
 			return false, nil
 		}
 
 		// Compute leaf CIDR of the identity
-		lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+		lbls := labels.NewLabelsFromModel(cidrID.Labels)
 		cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
 		if len(cidrModel) != 1 {
 			return false, errors.New("internal error")

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -160,12 +160,12 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 			if idObj.IsReservedIdentity() {
 				entry.Example = "reserved:" + idObj.String()
 			} else if idObj.HasLocalScope() {
-				response, err := client.queryLocalIdentity(ctx, p.Key.Identity)
+				cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
 				if err != nil {
 					return nil, err
 				}
-				if slices.Contains(response.Payload.Labels, "reserved:world") {
-					lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+				if slices.Contains(cidrID.Labels, "reserved:world") {
+					lbls := labels.NewLabelsFromModel(cidrID.Labels)
 					cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
 					if len(cidrModel) == 1 {
 						entry.Example = cidrModel[0]
@@ -215,7 +215,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 		func(pod *corev1.Pod) []inspectEntry {
 			result, err := runInspectOnPod(ctx, stderr, clientset, dynamicClient, filter, pod)
 			if err != nil {
-				fmt.Fprintf(stderr, "* %v\n", err)
+				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
 			return result

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"slices"
 	"sort"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -160,17 +158,11 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 			if idObj.IsReservedIdentity() {
 				entry.Example = "reserved:" + idObj.String()
 			} else if idObj.HasLocalScope() {
-				cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
+				cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
 				if err != nil {
 					return nil, err
 				}
-				if slices.Contains(cidrID.Labels, "reserved:world") {
-					lbls := labels.NewLabelsFromModel(cidrID.Labels)
-					cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
-					if len(cidrModel) == 1 {
-						entry.Example = cidrModel[0]
-					}
-				}
+				entry.Example = "cidr:" + cidr.String()
 			}
 		}
 		entry.Identity = p.Key.Identity

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -164,7 +164,7 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		func(pod *corev1.Pod) map[derivedFromEntry]any {
 			policy, err := runListOnPod(ctx, stderr, clientset, dynamicClient, pod)
 			if err != nil {
-				fmt.Fprintf(stderr, "* %v\n", err)
+				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
 			return policy

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -162,17 +160,11 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 				if idObj.IsReservedIdentity() {
 					entry.Example = "reserved:" + idObj.String()
 				} else if idObj.HasLocalScope() {
-					cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
+					cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
 					if err != nil {
 						return err
 					}
-					if slices.Contains(cidrID.Labels, "reserved:world") {
-						lbls := labels.NewLabelsFromModel(cidrID.Labels)
-						cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
-						if len(cidrModel) == 1 {
-							entry.Example = cidrModel[0]
-						}
-					}
+					entry.Example = "cidr:" + cidr.String()
 				}
 			}
 			entry.Identity = p.Key.Identity
@@ -249,17 +241,11 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 				if idObj.IsReservedIdentity() {
 					entry.Example = "reserved:" + idObj.String()
 				} else if idObj.HasLocalScope() {
-					cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
+					cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
 					if err != nil {
 						return err
 					}
-					if slices.Contains(cidrID.Labels, "reserved:world") {
-						lbls := labels.NewLabelsFromModel(cidrID.Labels)
-						cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
-						if len(cidrModel) == 1 {
-							entry.Example = cidrModel[0]
-						}
-					}
+					entry.Example = "cidr:" + cidr.String()
 				}
 			}
 			entry.Identity = p.Key.Identity

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -162,12 +162,12 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 				if idObj.IsReservedIdentity() {
 					entry.Example = "reserved:" + idObj.String()
 				} else if idObj.HasLocalScope() {
-					response, err := client.queryLocalIdentity(ctx, p.Key.Identity)
+					cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
 					if err != nil {
 						return err
 					}
-					if slices.Contains(response.Payload.Labels, "reserved:world") {
-						lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+					if slices.Contains(cidrID.Labels, "reserved:world") {
+						lbls := labels.NewLabelsFromModel(cidrID.Labels)
 						cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
 						if len(cidrModel) == 1 {
 							entry.Example = cidrModel[0]
@@ -249,12 +249,12 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 				if idObj.IsReservedIdentity() {
 					entry.Example = "reserved:" + idObj.String()
 				} else if idObj.HasLocalScope() {
-					response, err := client.queryLocalIdentity(ctx, p.Key.Identity)
+					cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
 					if err != nil {
 						return err
 					}
-					if slices.Contains(response.Payload.Labels, "reserved:world") {
-						lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+					if slices.Contains(cidrID.Labels, "reserved:world") {
+						lbls := labels.NewLabelsFromModel(cidrID.Labels)
 						cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
 						if len(cidrModel) == 1 {
 							entry.Example = cidrModel[0]

--- a/cmd/npv/app/summary.go
+++ b/cmd/npv/app/summary.go
@@ -88,7 +88,7 @@ func runSummary(ctx context.Context, stdout, stderr io.Writer) error {
 		func(pod *corev1.Pod) []summaryEntry {
 			entry, err := runSummaryOnPod(ctx, clientset, dynamicClient, pod)
 			if err != nil {
-				fmt.Fprintf(stderr, "* %v\n", err)
+				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
 			return []summaryEntry{entry}

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
-	"slices"
 	"sort"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -136,38 +133,28 @@ func runTrafficOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 			if idObj.IsReservedIdentity() {
 				example = "reserved:" + idObj.String()
 			} else if idObj.HasLocalScope() {
-				cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
+				cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
 				if err != nil {
 					return nil, err
 				}
-				if slices.Contains(cidrID.Labels, "reserved:world") {
-					lbls := labels.NewLabelsFromModel(cidrID.Labels)
-					cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
-					if len(cidrModel) == 1 {
-						// Cilium allocates different identity for a CIDR between nodes, so we cannot use it as a key.
-						// Instead, npv shows traffic as belonging to the world identity and differentiate it using CIDR.
-						k.Identity = uint32(identity.ReservedIdentityWorld)
-						cidr := strings.Split(cidrModel[0], ":")[1]
-						if trafficOptions.unifyExternal {
-							_, c, err := net.ParseCIDR(cidr)
-							if err != nil {
-								return nil, err
-							}
-							switch {
-							case isPrivateCIDR(c):
-								cidr = "private"
-							case isPublicCIDR(c):
-								cidr = "public"
-							default:
-								cidr = "unknown"
-							}
-							k.CIDR = cidr
-							example = fmt.Sprintf("cidr:%s", cidr)
-						} else {
-							k.CIDR = cidr
-							example = cidrModel[0]
-						}
+				// Cilium allocates different identity for a CIDR between nodes, so we cannot use it as a key.
+				// Instead, npv shows traffic as belonging to the world identity and differentiate it using CIDR.
+				k.Identity = uint32(identity.ReservedIdentityWorld)
+				if trafficOptions.unifyExternal {
+					var expr string
+					switch {
+					case isPrivateCIDR(cidr):
+						expr = "private"
+					case isPublicCIDR(cidr):
+						expr = "public"
+					default:
+						expr = "unknown"
 					}
+					k.CIDR = expr
+					example = fmt.Sprintf("cidr:%s", expr)
+				} else {
+					k.CIDR = cidr.String()
+					example = fmt.Sprintf("cidr:%s", cidr)
 				}
 			}
 		}

--- a/cmd/npv/app/traffic.go
+++ b/cmd/npv/app/traffic.go
@@ -136,12 +136,12 @@ func runTrafficOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 			if idObj.IsReservedIdentity() {
 				example = "reserved:" + idObj.String()
 			} else if idObj.HasLocalScope() {
-				response, err := client.queryLocalIdentity(ctx, p.Key.Identity)
+				cidrID, err := client.getCIDRIdentity(ctx, p.Key.Identity)
 				if err != nil {
 					return nil, err
 				}
-				if slices.Contains(response.Payload.Labels, "reserved:world") {
-					lbls := labels.NewLabelsFromModel(response.Payload.Labels)
+				if slices.Contains(cidrID.Labels, "reserved:world") {
+					lbls := labels.NewLabelsFromModel(cidrID.Labels)
 					cidrModel := lbls.GetFromSource(labels.LabelSourceCIDR).GetPrintableModel()
 					if len(cidrModel) == 1 {
 						// Cilium allocates different identity for a CIDR between nodes, so we cannot use it as a key.
@@ -223,7 +223,7 @@ func runTraffic(ctx context.Context, stdout, stderr io.Writer, name string) erro
 		func(pod *corev1.Pod) map[trafficKey]*trafficValue {
 			result, err := runTrafficOnPod(ctx, stderr, clientset, dynamicClient, filter, pod)
 			if err != nil {
-				fmt.Fprintf(stderr, "* %v\n", err)
+				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
 			return result

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -13,6 +13,68 @@ func testInspect() {
 		ExtraArgs []string
 		Expected  string
 	}{
+		// npv inspect should report result for each pod
+		// selectors are sorted alphabetically
+		{
+			Selector: "test=l3-egress-explicit-deny-all",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l3-egress-implicit-deny-all",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l3-ingress-explicit-allow-all",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0
+Allow,Ingress,self,true,true,0,0`,
+		},
+		{
+			Selector: "test=l3-ingress-explicit-deny-all",
+			Expected: `Deny,Ingress,self,true,true,0,0
+Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l3-ingress-implicit-deny-all",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l4-egress-explicit-deny-any",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l4-egress-explicit-deny-tcp",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l4-ingress-all-allow-tcp",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0
+Allow,Ingress,reserved:host,false,false,6,8000
+Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		{
+			Selector: "test=l4-ingress-explicit-allow-any",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0
+Allow,Ingress,self,false,false,6,53
+Allow,Ingress,self,false,false,17,53
+Allow,Ingress,self,false,false,132,53`,
+		},
+		{
+			Selector: "test=l4-ingress-explicit-allow-tcp",
+			Expected: `Allow,Ingress,reserved:host,true,true,0,0
+Allow,Ingress,self,false,false,6,8000`,
+		},
+		{
+			Selector: "test=l4-ingress-explicit-deny-any",
+			Expected: `Deny,Ingress,self,false,false,6,53
+Deny,Ingress,self,false,false,17,53
+Deny,Ingress,self,false,false,132,53
+Allow,Ingress,reserved:host,true,true,0,0`,
+		},
+		{
+			Selector: "test=l4-ingress-explicit-deny-udp",
+			Expected: `Deny,Ingress,self,false,false,17,161
+Allow,Ingress,reserved:host,true,true,0,0`,
+		},
 		{
 			Selector: "test=self",
 			Expected: `Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080
@@ -43,6 +105,22 @@ Allow,Egress,l4-ingress-explicit-deny-any,false,false,6,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,17,53
 Allow,Egress,l4-ingress-explicit-deny-any,false,false,132,53
 Allow,Egress,l4-ingress-explicit-deny-udp,false,false,17,161`,
+		},
+		// npv inspect should handle --with-cidrs
+		{
+			Selector:  "test=self",
+			ExtraArgs: []string{"--with-cidrs=0.0.0.0/0"},
+			Expected: `Deny,Ingress,cidr:192.168.100.0/24,false,false,6,8080
+Deny,Egress,cidr:8.8.4.4/32,false,false,6,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,17,53
+Deny,Egress,cidr:8.8.4.4/32,false,false,132,53
+Allow,Ingress,cidr:10.100.0.0/16,true,true,0,0
+Allow,Egress,cidr:1.1.1.1/32,false,false,6,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,17,53
+Allow,Egress,cidr:1.1.1.1/32,false,false,132,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
+Allow,Egress,cidr:8.8.8.8/32,false,false,132,53`,
 		},
 		{
 			Selector:  "test=self",
@@ -95,81 +173,40 @@ Allow,Egress,cidr:8.8.8.8/32,false,false,6,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,17,53
 Allow,Egress,cidr:8.8.8.8/32,false,false,132,53`,
 		},
-		{
-			Selector:  "test=l4-ingress-explicit-allow-tcp",
-			ExtraArgs: []string{"--used"},
-			Expected:  `Allow,Ingress,self,false,false,6,8000`,
-		},
-		{
-			Selector:  "test=l4-ingress-explicit-deny-udp",
-			ExtraArgs: []string{"--denied", "--unused"},
-			Expected:  `Deny,Ingress,self,false,false,17,161`,
-		},
-		{
-			Selector: "test=l3-ingress-explicit-allow-all",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,self,true,true,0,0`,
-		},
-		{
-			Selector: "test=l3-ingress-implicit-deny-all",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l3-ingress-explicit-deny-all",
-			Expected: `Deny,Ingress,self,true,true,0,0
-Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l3-egress-implicit-deny-all",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l3-egress-explicit-deny-all",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l4-ingress-explicit-allow-any",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,self,false,false,6,53
-Allow,Ingress,self,false,false,17,53
-Allow,Ingress,self,false,false,132,53`,
-		},
-		{
-			Selector: "test=l4-ingress-explicit-allow-tcp",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,self,false,false,6,8000`,
-		},
-		{
-			Selector: "test=l4-ingress-explicit-deny-any",
-			Expected: `Deny,Ingress,self,false,false,6,53
-Deny,Ingress,self,false,false,17,53
-Deny,Ingress,self,false,false,132,53
-Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l4-ingress-explicit-deny-udp",
-			Expected: `Deny,Ingress,self,false,false,17,161
-Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l4-egress-explicit-deny-any",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l4-egress-explicit-deny-tcp",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0`,
-		},
-		{
-			Selector: "test=l4-ingress-all-allow-tcp",
-			Expected: `Allow,Ingress,reserved:host,true,true,0,0
-Allow,Ingress,reserved:host,false,false,6,8000
-Allow,Ingress,reserved:unknown,false,false,6,8000`,
-		},
+		// npv inspect should handle reserved:unknown
 		{
 			Selector:  "test=l4-ingress-all-allow-tcp",
 			ExtraArgs: []string{"--with-cidrs=0.0.0.0/0"},
 			Expected:  `Allow,Ingress,reserved:unknown,false,false,6,8000`,
 		},
+		{
+			Selector:  "test=l4-ingress-all-allow-tcp",
+			ExtraArgs: []string{"--with-cidrs=10.0.0.0/8"},
+			Expected:  `Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		{
+			Selector:  "test=l4-ingress-all-allow-tcp",
+			ExtraArgs: []string{"--with-public-cidrs"},
+			Expected:  `Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		{
+			Selector:  "test=l4-ingress-all-allow-tcp",
+			ExtraArgs: []string{"--with-private-cidrs"},
+			Expected:  `Allow,Ingress,reserved:unknown,false,false,6,8000`,
+		},
+		// npv inspect should handle --used
+		{
+			Selector:  "test=l4-ingress-explicit-allow-tcp",
+			ExtraArgs: []string{"--used"},
+			Expected:  `Allow,Ingress,self,false,false,6,8000`,
+		},
+		// npv inspect should handle --unused
+		{
+			Selector:  "test=l4-ingress-explicit-deny-udp",
+			ExtraArgs: []string{"--denied", "--unused"},
+			Expected:  `Deny,Ingress,self,false,false,17,161`,
+		},
+		// npv inspect should handle --used without pod name
 		{
 			ExtraArgs: []string{"--used"},
 			Expected: `Allow,Ingress,self,true,true,0,0


### PR DESCRIPTION
Network Policy Viewer currently targets Cilium 1.16, where it can resolve a node-local CIDR identity in the Policy Map back to a CIDR on demand. This assumption will no longer hold in Cilium 1.17, because node-local identities and CIDRs are no longer guaranteed to have a one-to-one relationship.

To prepare for the Cilium 1.17 update, this PR changes Network Policy Viewer to fetch all local CIDR identities up front and build the identity-to-CIDR mapping once, rather than resolving each identity individually from the Policy Map.