### PR TITLE
Add --group option

### DIFF
--- a/cmd/npv/app/const.go
+++ b/cmd/npv/app/const.go
@@ -3,6 +3,10 @@ package app
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
+	subjectGroupAll       = "a" // all
+	subjectGroupNamespace = "n" // namespace, ns
+	subjectGroupPod       = "p" // pod, po
+
 	directionEgress  = "Egress"
 	directionIngress = "Ingress"
 

--- a/cmd/npv/app/const.go
+++ b/cmd/npv/app/const.go
@@ -3,9 +3,9 @@ package app
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 const (
-	subjectGroupAll       = "a" // all
-	subjectGroupNamespace = "n" // namespace, ns
-	subjectGroupPod       = "p" // pod, po
+	subjectGroupAll       = "all"
+	subjectGroupNamespace = "namespace"
+	subjectGroupPod       = "pod"
 
 	directionEgress  = "Egress"
 	directionIngress = "Ingress"

--- a/cmd/npv/app/helper_k8s.go
+++ b/cmd/npv/app/helper_k8s.go
@@ -87,6 +87,19 @@ func getPodIdentity(ctx context.Context, d *dynamic.DynamicClient, namespace, na
 	return uint32(identity), nil
 }
 
+func shouldPrintSubject(podName string) bool {
+	switch commonOptions.group {
+	case subjectGroupAll:
+		return false
+	case subjectGroupNamespace:
+		return rootOptions.allNamespaces
+	case subjectGroupPod:
+		return podName == ""
+	default:
+		panic("internal error")
+	}
+}
+
 func getSubjectNamespace() string {
 	if rootOptions.allNamespaces {
 		return ""
@@ -95,10 +108,19 @@ func getSubjectNamespace() string {
 }
 
 func getPodSubject(pod *corev1.Pod) string {
-	if rootOptions.allNamespaces {
-		return pod.Namespace + "/" + pod.Name
-	} else {
-		return pod.Name
+	switch commonOptions.group {
+	case subjectGroupAll:
+		return ""
+	case subjectGroupNamespace:
+		return pod.Namespace
+	case subjectGroupPod:
+		if rootOptions.allNamespaces {
+			return pod.Namespace + "/" + pod.Name
+		} else {
+			return pod.Name
+		}
+	default:
+		panic("internal error")
 	}
 }
 

--- a/cmd/npv/app/helper_proxy.go
+++ b/cmd/npv/app/helper_proxy.go
@@ -466,3 +466,51 @@ func mapNodeReduce[T any](pods []*corev1.Pod, initFunc func() T, mapFunc func(*c
 	}
 	return result
 }
+
+func compactBy[T any](x []T, cmp func(*T, *T) int, merge func(*T, *T) *T) []T {
+	ret := make([]T, 0, len(x))
+	if len(x) == 0 {
+		return ret
+	}
+
+	ret = append(ret, x[0])
+	for i := 1; i < len(x); i++ {
+		last := &ret[len(ret)-1]
+		next := &x[i]
+
+		if cmp(last, next) == 0 {
+			ret[len(ret)-1] = *merge(last, next)
+		} else {
+			ret = append(ret, *next)
+		}
+	}
+	return ret
+}
+
+func mergeBy[T any](x, y []T, cmp func(*T, *T) int, merge func(*T, *T) *T) []T {
+	var i, j int
+	ret := make([]T, 0, len(x)+len(y))
+
+	for i < len(x) && j < len(y) {
+		c := cmp(&x[i], &y[j])
+
+		switch {
+		case c < 0:
+			ret = append(ret, x[i])
+			i++
+
+		case c > 0:
+			ret = append(ret, y[j])
+			j++
+
+		default:
+			ret = append(ret, *merge(&x[i], &y[j]))
+			i++
+			j++
+		}
+	}
+
+	ret = append(ret, x[i:]...)
+	ret = append(ret, y[j:]...)
+	return ret
+}

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -28,6 +28,7 @@ func init() {
 	inspectCmd.Flags().BoolVar(&inspectOptions.denied, "denied", false, "show denied-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.used, "used", false, "show used-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.unused, "unused", false, "show unused-rules only")
+	addGroupOption(inspectCmd)
 	addSelectorOption(inspectCmd)
 	addWithCIDROptions(inspectCmd)
 	addDirectionOption(inspectCmd)
@@ -67,7 +68,7 @@ type inspectEntry struct {
 	Requests         uint64 `json:"requests"`
 }
 
-func lessInspectEntry(x, y *inspectEntry) bool {
+func compareInspectEntry(x, y *inspectEntry) int {
 	ret := strings.Compare(x.Subject, y.Subject)
 	if ret == 0 {
 		// List Deny first
@@ -89,7 +90,13 @@ func lessInspectEntry(x, y *inspectEntry) bool {
 	if ret == 0 {
 		ret = int(x.Port) - int(y.Port)
 	}
-	return ret < 0
+	return ret
+}
+
+func mergeInspectEntry(x, y *inspectEntry) *inspectEntry {
+	x.Bytes += y.Bytes
+	x.Requests += y.Requests
+	return x
 }
 
 func parseInspectOptions() {
@@ -178,6 +185,9 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 }
 
 func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) error {
+	if err := validateGroupOption(); err != nil {
+		return err
+	}
 	parseInspectOptions()
 	basicFilter := makeBasicFilter(
 		policyOptions.ingress, policyOptions.egress,
@@ -210,20 +220,17 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
-			return result
+			sort.Slice(result, func(i, j int) bool { return compareInspectEntry(&result[i], &result[j]) < 0 })
+			return compactBy(result, compareInspectEntry, mergeInspectEntry)
 		},
 		func(x, y []inspectEntry) []inspectEntry {
-			if y != nil {
-				x = append(x, y...)
-			}
-			return x
+			return mergeBy(x, y, compareInspectEntry, mergeInspectEntry)
 		},
 	)
-	sort.Slice(arr, func(i, j int) bool { return lessInspectEntry(&arr[i], &arr[j]) })
 
 	subHeader := []string{"SUBJECT", "|"}
 	header := []string{"POLICY", "DIRECTION", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "|", "BYTES:", "REQUESTS:", "AVERAGE:"}
-	if name == "" {
+	if shouldPrintSubject(name) {
 		header = append(subHeader, header...)
 	}
 	return writeSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
@@ -238,7 +245,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 		avg := fmt.Sprintf("%.1f", computeAverage(p.Bytes, p.Requests))
 		subValues := []any{p.Subject, "|"}
 		values := []any{p.Policy, p.Direction, "|", p.Identity, p.Namespace, p.Example, "|", protocol, port, "|", formatWithUnits(p.Bytes), formatWithUnits(p.Requests), avg}
-		if name == "" {
+		if shouldPrintSubject(name) {
 			values = append(subValues, values...)
 		}
 		return values

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -48,7 +48,7 @@ var listCmd = &cobra.Command{
 	ValidArgsFunction: completePods,
 }
 
-type derivedFromEntry struct {
+type listEntry struct {
 	Subject   string `json:"subject"`
 	Direction string `json:"direction"`
 	Kind      string `json:"kind"`
@@ -56,7 +56,7 @@ type derivedFromEntry struct {
 	Name      string `json:"name"`
 }
 
-func lessDerivedFromEntry(x, y *derivedFromEntry) bool {
+func lessListEntry(x, y *listEntry) bool {
 	ret := strings.Compare(x.Subject, y.Subject)
 	if ret == 0 {
 		ret = strings.Compare(x.Direction, y.Direction)
@@ -73,8 +73,8 @@ func lessDerivedFromEntry(x, y *derivedFromEntry) bool {
 	return ret < 0
 }
 
-func parseDerivedFromEntry(subject, direction string, input []string) derivedFromEntry {
-	val := derivedFromEntry{
+func parseListEntry(subject, direction string, input []string) listEntry {
+	val := listEntry{
 		Subject:   subject,
 		Direction: direction,
 		Namespace: "-",
@@ -92,8 +92,8 @@ func parseDerivedFromEntry(subject, direction string, input []string) derivedFro
 	return val
 }
 
-func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, pod *corev1.Pod) (map[derivedFromEntry]any, error) {
-	policySet := make(map[derivedFromEntry]any)
+func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, pod *corev1.Pod) (map[listEntry]any, error) {
+	policySet := make(map[listEntry]any)
 
 	client, err := createCiliumClient(ctx, stderr, clientset, pod.Namespace, pod.Name)
 	if err != nil {
@@ -127,7 +127,7 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 		ingressRules := response.Payload.Status.Policy.Realized.L4.Ingress
 		for _, rule := range ingressRules {
 			for _, r := range rule.DerivedFromRules {
-				entry := parseDerivedFromEntry(getPodSubject(pod), directionIngress, r)
+				entry := parseListEntry(getPodSubject(pod), directionIngress, r)
 				policySet[entry] = struct{}{}
 			}
 		}
@@ -136,7 +136,7 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 		egressRules := response.Payload.Status.Policy.Realized.L4.Egress
 		for _, rule := range egressRules {
 			for _, r := range rule.DerivedFromRules {
-				entry := parseDerivedFromEntry(getPodSubject(pod), directionEgress, r)
+				entry := parseListEntry(getPodSubject(pod), directionEgress, r)
 				policySet[entry] = struct{}{}
 			}
 		}
@@ -158,10 +158,10 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 
 	// The same rule appears multiple times in the response, so we need to dedup it
 	policySet := mapNodeReduce(pods,
-		func() map[derivedFromEntry]any {
-			return make(map[derivedFromEntry]any)
+		func() map[listEntry]any {
+			return make(map[listEntry]any)
 		},
-		func(pod *corev1.Pod) map[derivedFromEntry]any {
+		func(pod *corev1.Pod) map[listEntry]any {
 			policy, err := runListOnPod(ctx, stderr, clientset, dynamicClient, pod)
 			if err != nil {
 				fmt.Fprintf(stderr, "Warning: %v\n", err)
@@ -169,7 +169,7 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 			}
 			return policy
 		},
-		func(x, y map[derivedFromEntry]any) map[derivedFromEntry]any {
+		func(x, y map[listEntry]any) map[listEntry]any {
 			for k := range y {
 				x[k] = struct{}{}
 			}
@@ -178,7 +178,7 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	)
 
 	policyList := maps.Keys(policySet)
-	sort.Slice(policyList, func(i, j int) bool { return lessDerivedFromEntry(&policyList[i], &policyList[j]) })
+	sort.Slice(policyList, func(i, j int) bool { return lessListEntry(&policyList[i], &policyList[j]) })
 
 	if listOptions.manifests {
 		return listPolicyManifests(ctx, stdout, dynamicClient, policyList)
@@ -200,12 +200,12 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	})
 }
 
-func listPolicyManifests(ctx context.Context, w io.Writer, dynamicClient *dynamic.DynamicClient, policyList []derivedFromEntry) error {
+func listPolicyManifests(ctx context.Context, w io.Writer, dynamicClient *dynamic.DynamicClient, policyList []listEntry) error {
 	// remove direction info and sort again
 	for i := range policyList {
 		policyList[i].Direction = ""
 	}
-	sort.Slice(policyList, func(i, j int) bool { return lessDerivedFromEntry(&policyList[i], &policyList[j]) })
+	sort.Slice(policyList, func(i, j int) bool { return lessListEntry(&policyList[i], &policyList[j]) })
 
 	var previous types.NamespacedName
 	first := true

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/api/v1/client/endpoint"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,6 +27,7 @@ var listOptions struct {
 }
 
 func init() {
+	addGroupOption(listCmd)
 	addSelectorOption(listCmd)
 	addDirectionOption(listCmd)
 	listCmd.Flags().BoolVarP(&listOptions.manifests, "manifests", "m", false, "show policy manifests")
@@ -56,7 +58,7 @@ type listEntry struct {
 	Name      string `json:"name"`
 }
 
-func lessListEntry(x, y *listEntry) bool {
+func compareListEntry(x, y *listEntry) int {
 	ret := strings.Compare(x.Subject, y.Subject)
 	if ret == 0 {
 		ret = strings.Compare(x.Direction, y.Direction)
@@ -70,7 +72,11 @@ func lessListEntry(x, y *listEntry) bool {
 	if ret == 0 {
 		ret = strings.Compare(x.Name, y.Name)
 	}
-	return ret < 0
+	return ret
+}
+
+func mergeListEntry(x, y *listEntry) *listEntry {
+	return x
 }
 
 func parseListEntry(subject, direction string, input []string) listEntry {
@@ -92,7 +98,7 @@ func parseListEntry(subject, direction string, input []string) listEntry {
 	return val
 }
 
-func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, pod *corev1.Pod) (map[listEntry]any, error) {
+func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, pod *corev1.Pod) ([]listEntry, error) {
 	policySet := make(map[listEntry]any)
 
 	client, err := createCiliumClient(ctx, stderr, clientset, pod.Namespace, pod.Name)
@@ -142,10 +148,16 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 		}
 	}
 
-	return policySet, nil
+	policyList := slices.Collect(maps.Keys(policySet))
+	sort.Slice(policyList, func(i, j int) bool { return compareListEntry(&policyList[i], &policyList[j]) < 0 })
+	return policyList, nil
 }
 
 func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
+	if err := validateGroupOption(); err != nil {
+		return err
+	}
+
 	clientset, dynamicClient, err := createK8sClients()
 	if err != nil {
 		return fmt.Errorf("failed to create k8s clients: %w", err)
@@ -157,11 +169,11 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	}
 
 	// The same rule appears multiple times in the response, so we need to dedup it
-	policySet := mapNodeReduce(pods,
-		func() map[listEntry]any {
-			return make(map[listEntry]any)
+	arr := mapNodeReduce(pods,
+		func() []listEntry {
+			return make([]listEntry, 0)
 		},
-		func(pod *corev1.Pod) map[listEntry]any {
+		func(pod *corev1.Pod) []listEntry {
 			policy, err := runListOnPod(ctx, stderr, clientset, dynamicClient, pod)
 			if err != nil {
 				fmt.Fprintf(stderr, "Warning: %v\n", err)
@@ -169,31 +181,26 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 			}
 			return policy
 		},
-		func(x, y map[listEntry]any) map[listEntry]any {
-			for k := range y {
-				x[k] = struct{}{}
-			}
-			return x
+		func(x, y []listEntry) []listEntry {
+			return mergeBy(x, y, compareListEntry, mergeListEntry)
 		},
 	)
-
-	policyList := maps.Keys(policySet)
-	sort.Slice(policyList, func(i, j int) bool { return lessListEntry(&policyList[i], &policyList[j]) })
+	sort.Slice(arr, func(i, j int) bool { return compareListEntry(&arr[i], &arr[j]) < 0 })
 
 	if listOptions.manifests {
-		return listPolicyManifests(ctx, stdout, dynamicClient, policyList)
+		return listPolicyManifests(ctx, stdout, dynamicClient, arr)
 	}
 
 	subHeader := []string{"SUBJECT", "|"}
 	header := []string{"DIRECTION", "|", "KIND", "NAMESPACE", "NAME"}
-	if name == "" {
+	if shouldPrintSubject(name) {
 		header = append(subHeader, header...)
 	}
-	return writeSimpleOrJson(stdout, policyList, header, len(policyList), func(index int) []any {
-		p := policyList[index]
+	return writeSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
+		p := arr[index]
 		subValues := []any{p.Subject, "|"}
 		values := []any{p.Direction, "|", p.Kind, p.Namespace, p.Name}
-		if name == "" {
+		if shouldPrintSubject(name) {
 			values = append(subValues, values...)
 		}
 		return values
@@ -205,7 +212,7 @@ func listPolicyManifests(ctx context.Context, w io.Writer, dynamicClient *dynami
 	for i := range policyList {
 		policyList[i].Direction = ""
 	}
-	sort.Slice(policyList, func(i, j int) bool { return lessListEntry(&policyList[i], &policyList[j]) })
+	sort.Slice(policyList, func(i, j int) bool { return compareListEntry(&policyList[i], &policyList[j]) < 0 })
 
 	var previous types.NamespacedName
 	first := true

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -185,7 +185,6 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 			return mergeBy(x, y, compareListEntry, mergeListEntry)
 		},
 	)
-	sort.Slice(arr, func(i, j int) bool { return compareListEntry(&arr[i], &arr[j]) < 0 })
 
 	if listOptions.manifests {
 		return listPolicyManifests(ctx, stdout, dynamicClient, arr)

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -115,12 +115,12 @@ func addGroupOption(cmd *cobra.Command) {
 }
 
 func validateGroupOption() error {
-	switch {
-	case strings.HasPrefix(commonOptions.group, subjectGroupAll):
+	switch commonOptions.group {
+	case "a", "all":
 		commonOptions.group = subjectGroupAll
-	case strings.HasPrefix(commonOptions.group, subjectGroupNamespace):
+	case "n", "ns", "namespace", "namespaces":
 		commonOptions.group = subjectGroupNamespace
-	case strings.HasPrefix(commonOptions.group, subjectGroupPod):
+	case "p", "po", "pod", "pods":
 		commonOptions.group = subjectGroupPod
 	default:
 		return fmt.Errorf("failed to parse --group: should be one of: all (a), namespace (n), pod (p)")

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -73,6 +73,7 @@ func (c cidrOptions) isSet() bool {
 }
 
 var commonOptions struct {
+	group    string
 	selector string
 	with     cidrOptions
 }
@@ -107,6 +108,24 @@ func init() {
 	viper.SetEnvPrefix("npv")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
+}
+
+func addGroupOption(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&commonOptions.group, "group", "g", "pod", "experimental: merge entries within each subject group (pod, ns, all)")
+}
+
+func validateGroupOption() error {
+	switch {
+	case strings.HasPrefix(commonOptions.group, subjectGroupAll):
+		commonOptions.group = subjectGroupAll
+	case strings.HasPrefix(commonOptions.group, subjectGroupNamespace):
+		commonOptions.group = subjectGroupNamespace
+	case strings.HasPrefix(commonOptions.group, subjectGroupPod):
+		commonOptions.group = subjectGroupPod
+	default:
+		return fmt.Errorf("failed to parse --group: should be one of: all (a), namespace (n), pod (p)")
+	}
+	return nil
 }
 
 func addSelectorOption(cmd *cobra.Command) {

--- a/e2e/inspect_test.go
+++ b/e2e/inspect_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -242,6 +243,7 @@ Deny,Egress,l4-egress-explicit-deny-tcp,false,false,6,8000`,
 
 	It("should inspect policy configuration", func() {
 		for _, c := range cases {
+			By(fmt.Sprintf("inspecting %v %v", c.Selector, c.ExtraArgs))
 			args := []string{"inspect", "-o=json", "-n=test"}
 			if c.Selector != "" {
 				podName := onePodByLabelSelector(Default, "test", c.Selector)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.19.0
-	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
 	golang.org/x/mod v0.34.0
 	golang.org/x/term v0.41.0
 	k8s.io/api v0.35.2
@@ -103,6 +102,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
+	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect


### PR DESCRIPTION
- **Rename derivedFromEntry to listEntry**
- **Add --group option**

This PR adds `-g (--group)` option to `npv list` and `npv inspect`.

### -g pod (default)

`npv list -A -g pod` shows all the applied policies **per pod**.

```
root@ubuntu-75697f7bb7-6vckc:/# npv list -A -g pod
SUBJECT                                             | DIRECTION | KIND                           NAMESPACE NAME
test/l3-egress-explicit-deny-all-68d9cc6fc6-kl942   | Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-egress-explicit-deny-all-68d9cc6fc6-kl942   | Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-egress-implicit-deny-all-f577c5d67-mm8sc    | Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-egress-implicit-deny-all-f577c5d67-mm8sc    | Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-ingress-explicit-allow-all-79f5bd9c87-n7xds | Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-ingress-explicit-allow-all-79f5bd9c87-n7xds | Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-ingress-explicit-allow-all-79f5bd9c87-n7xds | Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
test/l3-ingress-explicit-allow-all-79f5bd9c87-wtwsf | Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-ingress-explicit-allow-all-79f5bd9c87-wtwsf | Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
test/l3-ingress-explicit-allow-all-79f5bd9c87-wtwsf | Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
...
```

### -g ns

`npv list -A -g ns` shows all the applied policies **per namespace**.

```
root@ubuntu-75697f7bb7-6vckc:/# npv list -A -g ns 
SUBJECT | DIRECTION | KIND                           NAMESPACE NAME
test    | Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
test    | Egress    | CiliumNetworkPolicy            test      l3-self
test    | Egress    | CiliumNetworkPolicy            test      l4-self
test    | Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
test    | Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
test    | Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-deny-all
test    | Ingress   | CiliumNetworkPolicy            test      l3-self
test    | Ingress   | CiliumNetworkPolicy            test      l4-ingress-all-allow-tcp
test    | Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-allow-any
test    | Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-allow-tcp
test    | Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-deny-any
test    | Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-deny-udp
test    | Ingress   | CiliumNetworkPolicy            test      l4-self
```

### -g all

`npv list -A -g all` shows all the applied policies **in the entire cluster**.
(`-A` without `-l` selects all the pods in the cluster for inspection, as `kubectl get` does).

```
root@ubuntu-75697f7bb7-6vckc:/# npv list -A -g all
DIRECTION | KIND                           NAMESPACE NAME
Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
Egress    | CiliumNetworkPolicy            test      l3-self
Egress    | CiliumNetworkPolicy            test      l4-self
Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-allow-all
Ingress   | CiliumNetworkPolicy            test      l3-ingress-explicit-deny-all
Ingress   | CiliumNetworkPolicy            test      l3-self
Ingress   | CiliumNetworkPolicy            test      l4-ingress-all-allow-tcp
Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-allow-any
Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-allow-tcp
Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-deny-any
Ingress   | CiliumNetworkPolicy            test      l4-ingress-explicit-deny-udp
Ingress   | CiliumNetworkPolicy            test      l4-self
```

### npv inspect
For `npv inspect`, it aggregates the traffic volume per route.
```
root@ubuntu-75697f7bb7-6vckc:/# npv inspect -n test -l test=self --used
SUBJECT               | POLICY DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
self-67c5cdddbd-5gxqd | Allow  Egress    | 16777219 -         cidr:1.1.1.1/32                                | UDP      53   |   744        8    93.0
self-67c5cdddbd-5gxqd | Allow  Egress    | 14846    test      l3-ingress-explicit-allow-all-79f5bd9c87-n7xds | ANY      ANY  |  3864       48    80.5
self-67c5cdddbd-5gxqd | Allow  Egress    | 5165     test      l4-ingress-explicit-allow-tcp-67776dc6db-w288v | TCP      8000 |  3864       48    80.5
self-67c5cdddbd-dzqzk | Allow  Egress    | 16777220 -         cidr:8.8.8.8/32                                | UDP      53   |   744        8    93.0
self-67c5cdddbd-dzqzk | Allow  Egress    | 14846    test      l3-ingress-explicit-allow-all-79f5bd9c87-n7xds | ANY      ANY  |  3864       48    80.5
self-67c5cdddbd-dzqzk | Allow  Egress    | 5165     test      l4-ingress-explicit-allow-tcp-67776dc6db-w288v | TCP      8000 |  3864       48    80.5
```

```
root@ubuntu-75697f7bb7-6vckc:/# npv inspect -n test -l test=self -g all --used   
POLICY DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
Allow  Egress    | 16777219 -         cidr:1.1.1.1/32                                | UDP      53   |   744        8    93.0
Allow  Egress    | 16777220 -         cidr:8.8.8.8/32                                | UDP      53   |   744        8    93.0
Allow  Egress    | 14846    test      l3-ingress-explicit-allow-all-79f5bd9c87-wtwsf | ANY      ANY  |  7728       96    80.5
Allow  Egress    | 5165     test      l4-ingress-explicit-allow-tcp-67776dc6db-w288v | TCP      8000 |  7728       96    80.5
```

This option benefits us as follows.
- We can list all the network policies applied to a specific namespace.
- We can integrate `npv traffic` into `npv inspect` in the near future. They provide very similar functionality but have different implementations, and thus the situation introduces undesirable maintenance cost.

Currently the flag is marked EXPERIMENTAL because it lacks enough test. I will transform tests for `npv traffic` to `npv inspect -g`, when I will remove `npv traffic`.