### PR TITLE
Unify common logic for npv inspect and npv reach

### DIFF
--- a/cmd/npv/app/helper_k8s.go
+++ b/cmd/npv/app/helper_k8s.go
@@ -107,17 +107,17 @@ func getSubjectNamespace() string {
 	return rootOptions.namespace
 }
 
-func getPodSubject(pod *corev1.Pod) string {
+func getPodSubject(namespace, name string) string {
 	switch commonOptions.group {
 	case subjectGroupAll:
 		return ""
 	case subjectGroupNamespace:
-		return pod.Namespace
+		return namespace
 	case subjectGroupPod:
 		if rootOptions.allNamespaces {
-			return pod.Namespace + "/" + pod.Name
+			return namespace + "/" + name
 		} else {
-			return pod.Name
+			return name
 		}
 	default:
 		panic("internal error")

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -147,7 +147,7 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 	arr := make([]inspectEntry, len(policies))
 	for i, p := range policies {
 		var entry inspectEntry
-		entry.Subject = getPodSubject(pod)
+		entry.Subject = getPodSubject(pod.Namespace, pod.Name)
 		entry.Node = pod.Spec.NodeName
 		if p.IsDeny() {
 			entry.Policy = policyDeny

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -59,6 +59,7 @@ var inspectCmd = &cobra.Command{
 // https://github.com/cilium/cilium/blob/v1.16.3/cilium-dbg/cmd/bpf_policy_get.go
 type inspectEntry struct {
 	Subject          string `json:"subject"`
+	Node             string `json:"node"`
 	Policy           string `json:"policy"`
 	Direction        string `json:"direction"`
 	Namespace        string `json:"namespace"`
@@ -98,6 +99,16 @@ func compareInspectEntry(x, y *inspectEntry) int {
 }
 
 func mergeInspectEntry(x, y *inspectEntry) *inspectEntry {
+	if x.Node != y.Node {
+		x.Node = ""
+		if x.Identity != y.Identity {
+			idObj := identity.NumericIdentity(x.Identity)
+			if idObj.HasLocalScope() {
+				x.Identity = uint32(identity.ReservedIdentityWorld)
+			}
+		}
+	}
+
 	x.Bytes += y.Bytes
 	x.Requests += y.Requests
 	return x
@@ -137,6 +148,7 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 	for i, p := range policies {
 		var entry inspectEntry
 		entry.Subject = getPodSubject(pod)
+		entry.Node = pod.Spec.NodeName
 		if p.IsDeny() {
 			entry.Policy = policyDeny
 		} else {

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -211,7 +211,9 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 		entry.Requests = p.Packets
 		arr[i] = entry
 	}
-	return arr, nil
+
+	sort.Slice(arr, func(i, j int) bool { return compareInspectEntry(&arr[i], &arr[j]) < 0 })
+	return compactBy(arr, compareInspectEntry, mergeInspectEntry), nil
 }
 
 func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) error {
@@ -250,8 +252,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 				fmt.Fprintf(stderr, "Warning: %v\n", err)
 				return nil
 			}
-			sort.Slice(result, func(i, j int) bool { return compareInspectEntry(&result[i], &result[j]) < 0 })
-			return compactBy(result, compareInspectEntry, mergeInspectEntry)
+			return result
 		},
 		func(x, y []inspectEntry) []inspectEntry {
 			return mergeBy(x, y, compareInspectEntry, mergeInspectEntry)

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -133,7 +133,7 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 		ingressRules := response.Payload.Status.Policy.Realized.L4.Ingress
 		for _, rule := range ingressRules {
 			for _, r := range rule.DerivedFromRules {
-				entry := parseListEntry(getPodSubject(pod), directionIngress, r)
+				entry := parseListEntry(getPodSubject(pod.Namespace, pod.Name), directionIngress, r)
 				policySet[entry] = struct{}{}
 			}
 		}
@@ -142,7 +142,7 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 		egressRules := response.Payload.Status.Policy.Realized.L4.Egress
 		for _, rule := range egressRules {
 			for _, r := range rule.DerivedFromRules {
-				entry := parseListEntry(getPodSubject(pod), directionEgress, r)
+				entry := parseListEntry(getPodSubject(pod.Namespace, pod.Name), directionEgress, r)
 				policySet[entry] = struct{}{}
 			}
 		}

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -46,18 +45,8 @@ var reachCmd = &cobra.Command{
 }
 
 type reachEntry struct {
-	Role             string `json:"role"`
-	Direction        string `json:"direction"`
-	Policy           string `json:"policy"`
-	Identity         uint32 `json:"identity"`
-	Namespace        string `json:"namespace"`
-	Example          string `json:"example_endpoint"`
-	WildcardProtocol bool   `json:"wildcard_protocol"`
-	WildcardPort     bool   `json:"wildcard_port"`
-	Protocol         uint8  `json:"protocol"`
-	Port             uint16 `json:"port"`
-	Bytes            uint64 `json:"bytes"`
-	Requests         uint64 `json:"requests"`
+	inspectEntry
+	Role string `json:"role"`
 }
 
 func runReach(ctx context.Context, stdout, stderr io.Writer) error {
@@ -89,11 +78,6 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	ids, err := getIdentityResourceMap(ctx, dynamicClient)
-	if err != nil {
-		return err
-	}
-
 	arr := make([]reachEntry, 0)
 
 	// process from-egress
@@ -116,65 +100,21 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 			return errors.New("one of --to or --to-cidrs must be specified")
 		}
 
-		client, err := createCiliumClient(ctx, stderr, clientset, from.Namespace, from.Name)
+		pod, err := clientset.CoreV1().Pods(from.Namespace).Get(ctx, from.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		policies, err := queryPolicyMap(ctx, clientset, dynamicClient, from.Namespace, from.Name)
+		rules, err := runInspectOnPod(ctx, stderr, clientset, dynamicClient, filter, pod)
 		if err != nil {
 			return err
 		}
-		if policies, err = filterPolicyMap(ctx, client, policies, filter); err != nil {
-			return err
-		}
 
-		for _, p := range policies {
-			var entry reachEntry
-			entry.Role = trafficRoleSender
-			entry.Direction = directionEgress
-			if p.IsDeny() {
-				entry.Policy = policyDeny
-			} else {
-				entry.Policy = policyAllow
-			}
-			entry.Namespace = "-"
-			if id, ok := ids[p.Key.Identity]; ok {
-				ns, ok, err := unstructured.NestedString(id.Object, "security-labels", "k8s:io.kubernetes.pod.namespace")
-				if err != nil {
-					return err
-				}
-				if ok {
-					entry.Namespace = ns
-				}
-			}
-			entry.Example = "-"
-			example, err := getIdentityExample(ctx, dynamicClient, p.Key.Identity)
-			if err != nil {
-				return err
-			}
-			if example != nil {
-				entry.Example = example.GetName()
-			} else {
-				idObj := identity.NumericIdentity(p.Key.Identity)
-				if idObj.IsReservedIdentity() {
-					entry.Example = "reserved:" + idObj.String()
-				} else if idObj.HasLocalScope() {
-					cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
-					if err != nil {
-						return err
-					}
-					entry.Example = "cidr:" + cidr.String()
-				}
-			}
-			entry.Identity = p.Key.Identity
-			entry.WildcardProtocol = p.IsWildcardProtocol()
-			entry.WildcardPort = p.IsWildcardPort()
-			entry.Protocol = p.GetProtocol()
-			entry.Port = p.Key.GetDestPort()
-			entry.Bytes = p.Bytes
-			entry.Requests = p.Packets
-			arr = append(arr, entry)
+		for _, r := range rules {
+			arr = append(arr, reachEntry{
+				inspectEntry: r,
+				Role:         trafficRoleSender,
+			})
 		}
 	}
 	// process to-ingress
@@ -197,65 +137,21 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 			return errors.New("one of --from or --from-cidrs must be specified")
 		}
 
-		client, err := createCiliumClient(ctx, stderr, clientset, to.Namespace, to.Name)
+		pod, err := clientset.CoreV1().Pods(to.Namespace).Get(ctx, to.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		policies, err := queryPolicyMap(ctx, clientset, dynamicClient, to.Namespace, to.Name)
+		rules, err := runInspectOnPod(ctx, stderr, clientset, dynamicClient, filter, pod)
 		if err != nil {
 			return err
 		}
-		if policies, err = filterPolicyMap(ctx, client, policies, filter); err != nil {
-			return err
-		}
 
-		for _, p := range policies {
-			var entry reachEntry
-			entry.Role = trafficRoleReceiver
-			entry.Direction = directionIngress
-			if p.IsDeny() {
-				entry.Policy = policyDeny
-			} else {
-				entry.Policy = policyAllow
-			}
-			entry.Namespace = "-"
-			if id, ok := ids[p.Key.Identity]; ok {
-				ns, ok, err := unstructured.NestedString(id.Object, "security-labels", "k8s:io.kubernetes.pod.namespace")
-				if err != nil {
-					return err
-				}
-				if ok {
-					entry.Namespace = ns
-				}
-			}
-			entry.Example = "-"
-			example, err := getIdentityExample(ctx, dynamicClient, p.Key.Identity)
-			if err != nil {
-				return err
-			}
-			if example != nil {
-				entry.Example = example.GetName()
-			} else {
-				idObj := identity.NumericIdentity(p.Key.Identity)
-				if idObj.IsReservedIdentity() {
-					entry.Example = "reserved:" + idObj.String()
-				} else if idObj.HasLocalScope() {
-					cidr, err := client.getCIDRForIdentity(ctx, p.Key.Identity)
-					if err != nil {
-						return err
-					}
-					entry.Example = "cidr:" + cidr.String()
-				}
-			}
-			entry.Identity = p.Key.Identity
-			entry.WildcardProtocol = p.IsWildcardProtocol()
-			entry.WildcardPort = p.IsWildcardPort()
-			entry.Protocol = p.GetProtocol()
-			entry.Port = p.Key.GetDestPort()
-			entry.Bytes = p.Bytes
-			entry.Requests = p.Packets
-			arr = append(arr, entry)
+		for _, r := range rules {
+			arr = append(arr, reachEntry{
+				inspectEntry: r,
+				Role:         trafficRoleReceiver,
+			})
 		}
 	}
 

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -28,6 +28,7 @@ func init() {
 	reachCmd.Flags().StringVar(&reachOptions.toCIDR.cidrs, "to-cidrs", "", "destination CIDRs")
 	reachCmd.Flags().BoolVar(&reachOptions.toCIDR.privateCIDRs, "to-private-cidrs", false, "use private CIDRs as destination (10.0.0.0/8,172.16.0.0/12,192.168.0.0/16)")
 	reachCmd.Flags().BoolVar(&reachOptions.toCIDR.publicCIDRs, "to-public-cidrs", false, "use public CIDRs as destination (0.0.0.0/0,!10.0.0.0/8,!172.16.0.0/12,!192.168.0.0/16)")
+	reachCmd.Flags().BoolVar(&inspectOptions.maskCIDRs, "mask-cidrs", false, "mask cluster-external CIDRs and unify them into public, private, and unknown")
 	reachCmd.RegisterFlagCompletionFunc("from", completeNamespacePods)
 	reachCmd.RegisterFlagCompletionFunc("to", completeNamespacePods)
 	rootCmd.AddCommand(reachCmd)

--- a/cmd/npv/app/subject.go
+++ b/cmd/npv/app/subject.go
@@ -48,7 +48,7 @@ func runSubject(ctx context.Context, stdout io.Writer, name string) error {
 
 	subjects := make([]string, len(pods))
 	for i, p := range pods {
-		subjects[i] = getPodSubject(p)
+		subjects[i] = getPodSubject(p.Namespace, p.Name)
 	}
 	subjects = slices.Unique(subjects)
 


### PR DESCRIPTION
This PR includes several minor improvements.

### Fix incorrect reporting of node-local identities in npv inspect

This commit assigns `reserved:world` to aggregated policy map entries when the original entries come from different nodes and correspond to node-local identities.

### Change the signature of getPodSubject

This commit changes `getPodSubject(pod *corev1.Pod)` to `getPodSubject(namespace, name string)`.

### Unify common logic for npv inspect and npv reach

Both `npv inspect` and `npv reach` inspect policy maps, but their implementations were separate.
This commit unifies their internal logic.

### Add the --mask-cidrs option to the reach command

This commit adds support for `npv reach --mask-cidrs`.