### PR TITLE
Extract subject settings into pkg/subject

### DIFF
--- a/cmd/npv/app/agent_pod.go
+++ b/cmd/npv/app/agent_pod.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
 
 func init() {
@@ -31,7 +33,9 @@ func runAgentPod(ctx context.Context, w io.Writer, name string) error {
 		return err
 	}
 
-	pod, err := clientset.CoreV1().Pods(rootOptions.namespace).Get(ctx, name, metav1.GetOptions{})
+	selector := subject.GetSelectorConfig()
+
+	pod, err := clientset.CoreV1().Pods(selector.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/const.go
+++ b/cmd/npv/app/const.go
@@ -1,10 +1,6 @@
 package app
 
 const (
-	subjectGroupAll       = "all"
-	subjectGroupNamespace = "namespace"
-	subjectGroupPod       = "pod"
-
 	directionEgress  = "Egress"
 	directionIngress = "Ingress"
 

--- a/cmd/npv/app/dump.go
+++ b/cmd/npv/app/dump.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
 
 func init() {
@@ -33,12 +34,14 @@ func runDump(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		return err
 	}
 
-	client, err := proxy.CreateCiliumClient(ctx, stderr, clientset, dynamicClient, rootOptions.namespace, name)
+	selector := subject.GetSelectorConfig()
+
+	client, err := proxy.CreateCiliumClient(ctx, stderr, clientset, dynamicClient, selector.Namespace, name)
 	if err != nil {
 		return err
 	}
 
-	data, err := client.DumpEndpoint(ctx, rootOptions.namespace, name)
+	data, err := client.DumpEndpoint(ctx, selector.Namespace, name)
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/helper_k8s.go
+++ b/cmd/npv/app/helper_k8s.go
@@ -74,11 +74,13 @@ func getPodIdentity(ctx context.Context, d *dynamic.DynamicClient, namespace, na
 }
 
 func shouldPrintSubject(podName string) bool {
+	selector := subject.GetSelectorConfig()
+
 	switch subject.GetGroup() {
 	case subject.GroupAll:
 		return false
 	case subject.GroupNamespace:
-		return rootOptions.allNamespaces
+		return selector.AllNamespaces
 	case subject.GroupPod:
 		return podName == ""
 	default:
@@ -87,20 +89,23 @@ func shouldPrintSubject(podName string) bool {
 }
 
 func getSubjectNamespace() string {
-	if rootOptions.allNamespaces {
+	selector := subject.GetSelectorConfig()
+	if selector.AllNamespaces {
 		return ""
 	}
-	return rootOptions.namespace
+	return selector.Namespace
 }
 
 func getPodSubject(namespace, name string) string {
+	selector := subject.GetSelectorConfig()
+
 	switch subject.GetGroup() {
 	case subject.GroupAll:
 		return ""
 	case subject.GroupNamespace:
 		return namespace
 	case subject.GroupPod:
-		if rootOptions.allNamespaces {
+		if selector.AllNamespaces {
 			return namespace + "/" + name
 		} else {
 			return name
@@ -110,8 +115,10 @@ func getPodSubject(namespace, name string) string {
 	}
 }
 
-func selectSubjectPods(ctx context.Context, clientset *kubernetes.Clientset, name, selector string) ([]*corev1.Pod, error) {
-	if (name != "") && (rootOptions.allNamespaces || selector != "") {
+func listSubjectPods(ctx context.Context, clientset *kubernetes.Clientset, name string) ([]*corev1.Pod, error) {
+	selector := subject.GetSelectorConfig()
+
+	if (name != "") && (selector.AllNamespaces || selector.PodSelector != "") {
 		return nil, errors.New("multiple pods should not be selected when pod name is specified")
 	}
 
@@ -124,11 +131,11 @@ func selectSubjectPods(ctx context.Context, clientset *kubernetes.Clientset, nam
 		return []*corev1.Pod{pod}, nil
 	} else {
 		opts := metav1.ListOptions{
-			LabelSelector: selector,
+			LabelSelector: selector.PodSelector,
 		}
-		node := rootOptions.node
+		node := selector.Node
 		if node != "" {
-			opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", rootOptions.node).String()
+			opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", selector.Node).String()
 		}
 
 		return listCiliumManagedPods(ctx, clientset, ns, opts)

--- a/cmd/npv/app/helper_k8s.go
+++ b/cmd/npv/app/helper_k8s.go
@@ -19,6 +19,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/gvr"
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
 
 var (
@@ -73,12 +74,12 @@ func getPodIdentity(ctx context.Context, d *dynamic.DynamicClient, namespace, na
 }
 
 func shouldPrintSubject(podName string) bool {
-	switch commonOptions.group {
-	case subjectGroupAll:
+	switch subject.GetGroup() {
+	case subject.GroupAll:
 		return false
-	case subjectGroupNamespace:
+	case subject.GroupNamespace:
 		return rootOptions.allNamespaces
-	case subjectGroupPod:
+	case subject.GroupPod:
 		return podName == ""
 	default:
 		panic("internal error")
@@ -93,12 +94,12 @@ func getSubjectNamespace() string {
 }
 
 func getPodSubject(namespace, name string) string {
-	switch commonOptions.group {
-	case subjectGroupAll:
+	switch subject.GetGroup() {
+	case subject.GroupAll:
 		return ""
-	case subjectGroupNamespace:
+	case subject.GroupNamespace:
 		return namespace
-	case subjectGroupPod:
+	case subject.GroupPod:
 		if rootOptions.allNamespaces {
 			return namespace + "/" + name
 		} else {

--- a/cmd/npv/app/id_tree.go
+++ b/cmd/npv/app/id_tree.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/gvr"
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
 
 func init() {
@@ -47,6 +48,8 @@ func runIdTree(ctx context.Context, w io.Writer) error {
 		return err
 	}
 
+	selector := subject.GetSelectorConfig()
+
 	items := make([]idTreeEntry, 0)
 	for _, item := range li.Items {
 		var e idTreeEntry
@@ -64,7 +67,7 @@ func runIdTree(ctx context.Context, w io.Writer) error {
 			continue
 		}
 		if ns, ok := labels["k8s:io.kubernetes.pod.namespace"]; ok {
-			if !(rootOptions.allNamespaces || ns == rootOptions.namespace) {
+			if !(selector.AllNamespaces || ns == selector.Namespace) {
 				continue
 			}
 		}

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -235,7 +235,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 		return err
 	}
 
-	pods, err := selectSubjectPods(ctx, clientset, name, commonOptions.selector)
+	pods, err := listSubjectPods(ctx, clientset, name)
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -141,7 +141,7 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		return fmt.Errorf("failed to create k8s clients: %w", err)
 	}
 
-	pods, err := selectSubjectPods(ctx, clientset, name, commonOptions.selector)
+	pods, err := listSubjectPods(ctx, clientset, name)
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/cidr"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
 
 const (
@@ -69,15 +70,12 @@ func fillRootOptions(cmd *cobra.Command) error {
 
 func fillGroupOptions(cmd *cobra.Command) error {
 	if cmd.Flags().Lookup(flagGroup) != nil {
-		switch commonOptions.group {
-		case "a", "all":
-			commonOptions.group = subjectGroupAll
-		case "n", "ns", "namespace", "namespaces":
-			commonOptions.group = subjectGroupNamespace
-		case "p", "po", "pod", "pods", "":
-			commonOptions.group = subjectGroupPod
-		default:
-			return fmt.Errorf("failed to parse --group: should be one of: pod [p], ns [n], all [a]")
+		group, err := cmd.Flags().GetString(flagGroup)
+		if err != nil {
+			return err
+		}
+		if err := subject.SetGroup(group); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -94,7 +92,6 @@ func (c cidrOptions) isSet() bool {
 }
 
 var commonOptions struct {
-	group    string
 	selector string
 	with     cidrOptions
 }
@@ -143,7 +140,7 @@ func init() {
 }
 
 func addGroupOption(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&commonOptions.group, flagGroup, "g", "pod", "experimental: merge entries within each subject group (pod [p], ns [n], all [a])")
+	cmd.Flags().StringP(flagGroup, "g", "pod", "experimental: merge entries within each subject group (pod [p], ns [n], all [a])")
 }
 
 func addSelectorOption(cmd *cobra.Command) {

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -31,34 +31,22 @@ const (
 	flagUnits          = "units"
 	flagJobs           = "jobs"
 
-	flagGroup = "group"
+	flagGroup       = "group"
+	flagPodSelector = "selector"
 )
 
 var rootOptions struct {
-	namespace     string
-	allNamespaces bool
-	node          string
-	output        string
-	noHeaders     bool
-	units         bool
-	jobs          int
+	output    string
+	noHeaders bool
+	units     bool
+	jobs      int
 }
 
-func fillRootOptions(cmd *cobra.Command) error {
-	rootOptions.namespace = viper.GetString(flagNamespace)
-	rootOptions.allNamespaces = viper.GetBool(flagAllNamespaces)
-	rootOptions.node = viper.GetString(flagNode)
+func fillRootOptions() error {
 	rootOptions.output = viper.GetString(flagOutput)
 	rootOptions.noHeaders = viper.GetBool(flagNoHeaders)
 	rootOptions.units = viper.GetBool(flagUnits)
 	rootOptions.jobs = viper.GetInt(flagJobs)
-
-	if rootOptions.node != "" {
-		rootOptions.allNamespaces = true
-	}
-	if rootOptions.allNamespaces && cmd.Flags().Changed(flagNamespace) {
-		return errors.New("namespace (-n) and all-namespaces (-A) should not be specified at once")
-	}
 
 	proxy.SetConfig(&proxy.Config{
 		Namespace: viper.GetString(flagProxyNamespace),
@@ -91,9 +79,33 @@ func (c cidrOptions) isSet() bool {
 	return c.cidrs != "" || c.privateCIDRs || c.publicCIDRs
 }
 
+func fillSelectorOptions(cmd *cobra.Command) error {
+	config := &subject.SelectorConfig{
+		AllNamespaces: viper.GetBool(flagAllNamespaces),
+		Namespace:     viper.GetString(flagNamespace),
+		Node:          viper.GetString(flagNode),
+	}
+
+	if cmd.Flags().Lookup(flagPodSelector) != nil {
+		v, err := cmd.Flags().GetString(flagPodSelector)
+		if err != nil {
+			return err
+		}
+		config.PodSelector = v
+	}
+
+	if config.Node != "" {
+		config.AllNamespaces = true
+	}
+	if config.AllNamespaces && cmd.Flags().Changed(flagNamespace) {
+		return errors.New("namespace (-n) and all-namespaces (-A) should not be specified at once")
+	}
+	subject.SetSelectorConfig(config)
+	return nil
+}
+
 var commonOptions struct {
-	selector string
-	with     cidrOptions
+	with cidrOptions
 }
 
 var policyOptions struct {
@@ -109,10 +121,13 @@ func fillPolicyOptions() {
 }
 
 func fillOptions(cmd *cobra.Command) error {
-	if err := fillRootOptions(cmd); err != nil {
+	if err := fillRootOptions(); err != nil {
 		return err
 	}
 	if err := fillGroupOptions(cmd); err != nil {
+		return err
+	}
+	if err := fillSelectorOptions(cmd); err != nil {
 		return err
 	}
 	fillPolicyOptions()
@@ -144,7 +159,7 @@ func addGroupOption(cmd *cobra.Command) {
 }
 
 func addSelectorOption(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&commonOptions.selector, "selector", "l", "", "specify label constraints")
+	cmd.Flags().StringP(flagPodSelector, "l", "", "specify label constraints")
 }
 
 func addDirectionOption(cmd *cobra.Command) {

--- a/cmd/npv/app/subject.go
+++ b/cmd/npv/app/subject.go
@@ -37,7 +37,7 @@ func runSubject(ctx context.Context, stdout io.Writer, name string) error {
 		return fmt.Errorf("failed to create k8s clients: %w", err)
 	}
 
-	pods, err := selectSubjectPods(ctx, clientset, name, commonOptions.selector)
+	pods, err := listSubjectPods(ctx, clientset, name)
 	if err != nil {
 		return err
 	}

--- a/cmd/npv/app/summary.go
+++ b/cmd/npv/app/summary.go
@@ -83,7 +83,7 @@ func runSummary(ctx context.Context, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	pods, err := selectSubjectPods(ctx, clientset, "", "")
+	pods, err := listSubjectPods(ctx, clientset, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -1,0 +1,36 @@
+package subject
+
+import "fmt"
+
+const (
+	GroupAll       = "all"
+	GroupNamespace = "namespace"
+	GroupPod       = "pod"
+)
+
+var (
+	group string
+)
+
+func init() {
+	group = GroupPod
+}
+
+func GetGroup() string {
+	return group
+}
+
+func SetGroup(g string) error {
+	switch g {
+	case "a", "all":
+		g = GroupAll
+	case "n", "ns", "namespace", "namespaces":
+		g = GroupNamespace
+	case "p", "po", "pod", "pods", "":
+		g = GroupPod
+	default:
+		return fmt.Errorf("failed to parse --group: should be one of: all [a], ns [n], pod [p]")
+	}
+	group = g
+	return nil
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -8,8 +8,16 @@ const (
 	GroupPod       = "pod"
 )
 
+type SelectorConfig struct {
+	AllNamespaces bool
+	Namespace     string
+	PodSelector   string
+	Node          string
+}
+
 var (
-	group string
+	group          string
+	selectorConfig *SelectorConfig
 )
 
 func init() {
@@ -33,4 +41,12 @@ func SetGroup(g string) error {
 	}
 	group = g
 	return nil
+}
+
+func GetSelectorConfig() *SelectorConfig {
+	return selectorConfig
+}
+
+func SetSelectorConfig(c *SelectorConfig) {
+	selectorConfig = c
 }


### PR DESCRIPTION
This PR moves the group and selector settings to `pkg/subject`.
The next one will move the helper functions for selecting subjects to `pkg/subject` (e.g. `listSubjectPods`).

- **Move group setting to pkg/subject**
- **Move selector setting to pkg/subject**

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
