### PR TITLE
Refactor initialization of common flags

### DIFF
--- a/cmd/npv/app/helper_completion.go
+++ b/cmd/npv/app/helper_completion.go
@@ -11,7 +11,7 @@ import (
 func completeNamespaces(cmd *cobra.Command, args []string, toComplete string) (ret []string, directive cobra.ShellCompDirective) {
 	ret = make([]string, 0)
 	directive = cobra.ShellCompDirectiveNoFileComp
-	if err := fillRootOptions(cmd); err != nil {
+	if err := fillOptions(cmd); err != nil {
 		return
 	}
 
@@ -34,7 +34,7 @@ func completeNamespaces(cmd *cobra.Command, args []string, toComplete string) (r
 func completeNodes(cmd *cobra.Command, args []string, toComplete string) (ret []string, directive cobra.ShellCompDirective) {
 	ret = make([]string, 0)
 	directive = cobra.ShellCompDirectiveNoFileComp
-	if err := fillRootOptions(cmd); err != nil {
+	if err := fillOptions(cmd); err != nil {
 		return
 	}
 
@@ -57,7 +57,7 @@ func completeNodes(cmd *cobra.Command, args []string, toComplete string) (ret []
 func completePods(cmd *cobra.Command, args []string, toComplete string) (ret []string, directive cobra.ShellCompDirective) {
 	ret = make([]string, 0)
 	directive = cobra.ShellCompDirectiveNoFileComp
-	if err := fillRootOptions(cmd); err != nil {
+	if err := fillOptions(cmd); err != nil {
 		return
 	}
 
@@ -80,7 +80,7 @@ func completePods(cmd *cobra.Command, args []string, toComplete string) (ret []s
 func completeNamespacePods(cmd *cobra.Command, args []string, toComplete string) (ret []string, directive cobra.ShellCompDirective) {
 	ret = make([]string, 0)
 	directive = cobra.ShellCompDirectiveNoFileComp
-	if err := fillRootOptions(cmd); err != nil {
+	if err := fillOptions(cmd); err != nil {
 		return
 	}
 

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -218,9 +218,6 @@ func runInspectOnPod(ctx context.Context, stderr io.Writer, clientset *kubernete
 }
 
 func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) error {
-	if err := validateGroupOption(); err != nil {
-		return err
-	}
 	parseInspectOptions()
 	basicFilter := proxy.MakeBasicFilter(
 		policyOptions.ingress, policyOptions.egress,

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -136,10 +136,6 @@ func runListOnPod(ctx context.Context, stderr io.Writer, clientset *kubernetes.C
 }
 
 func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
-	if err := validateGroupOption(); err != nil {
-		return err
-	}
-
 	clientset, dynamicClient, err := createK8sClients()
 	if err != nil {
 		return fmt.Errorf("failed to create k8s clients: %w", err)

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -32,25 +32,19 @@ const (
 )
 
 var rootOptions struct {
-	namespace      string
-	allNamespaces  bool
-	node           string
-	proxyNamespace string
-	proxySelector  string
-	proxyPort      uint16
-	output         string
-	noHeaders      bool
-	units          bool
-	jobs           int
+	namespace     string
+	allNamespaces bool
+	node          string
+	output        string
+	noHeaders     bool
+	units         bool
+	jobs          int
 }
 
 func fillRootOptions(cmd *cobra.Command) error {
 	rootOptions.namespace = viper.GetString(flagNamespace)
 	rootOptions.allNamespaces = viper.GetBool(flagAllNamespaces)
 	rootOptions.node = viper.GetString(flagNode)
-	rootOptions.proxyNamespace = viper.GetString(flagProxyNamespace)
-	rootOptions.proxySelector = viper.GetString(flagProxySelector)
-	rootOptions.proxyPort = viper.GetUint16(flagProxyPort)
 	rootOptions.output = viper.GetString(flagOutput)
 	rootOptions.noHeaders = viper.GetBool(flagNoHeaders)
 	rootOptions.units = viper.GetBool(flagUnits)
@@ -62,10 +56,11 @@ func fillRootOptions(cmd *cobra.Command) error {
 	if rootOptions.allNamespaces && cmd.Flags().Changed(flagNamespace) {
 		return errors.New("namespace (-n) and all-namespaces (-A) should not be specified at once")
 	}
-	proxy.SetProxyConfig(&proxy.ProxyConfig{
-		Namespace: rootOptions.proxyNamespace,
-		Selector:  rootOptions.proxySelector,
-		Port:      rootOptions.proxyPort,
+
+	proxy.SetConfig(&proxy.Config{
+		Namespace: viper.GetString(flagProxyNamespace),
+		Selector:  viper.GetString(flagProxySelector),
+		Port:      viper.GetUint16(flagProxyPort),
 	})
 	return nil
 }

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -29,6 +29,8 @@ const (
 	flagNoHeaders      = "no-headers"
 	flagUnits          = "units"
 	flagJobs           = "jobs"
+
+	flagGroup = "group"
 )
 
 var rootOptions struct {
@@ -65,6 +67,22 @@ func fillRootOptions(cmd *cobra.Command) error {
 	return nil
 }
 
+func fillGroupOptions(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup(flagGroup) != nil {
+		switch commonOptions.group {
+		case "a", "all":
+			commonOptions.group = subjectGroupAll
+		case "n", "ns", "namespace", "namespaces":
+			commonOptions.group = subjectGroupNamespace
+		case "p", "po", "pod", "pods", "":
+			commonOptions.group = subjectGroupPod
+		default:
+			return fmt.Errorf("failed to parse --group: should be one of: pod [p], ns [n], all [a]")
+		}
+	}
+	return nil
+}
+
 type cidrOptions struct {
 	cidrs        string
 	privateCIDRs bool
@@ -93,6 +111,17 @@ func fillPolicyOptions() {
 	}
 }
 
+func fillOptions(cmd *cobra.Command) error {
+	if err := fillRootOptions(cmd); err != nil {
+		return err
+	}
+	if err := fillGroupOptions(cmd); err != nil {
+		return err
+	}
+	fillPolicyOptions()
+	return nil
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringP(flagNamespace, "n", "default", "namespace of pods")
 	rootCmd.PersistentFlags().BoolP(flagAllNamespaces, "A", false, "show pods across all namespaces")
@@ -114,21 +143,7 @@ func init() {
 }
 
 func addGroupOption(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&commonOptions.group, "group", "g", "pod", "experimental: merge entries within each subject group (pod [p], ns [n], all [a])")
-}
-
-func validateGroupOption() error {
-	switch commonOptions.group {
-	case "a", "all":
-		commonOptions.group = subjectGroupAll
-	case "n", "ns", "namespace", "namespaces":
-		commonOptions.group = subjectGroupNamespace
-	case "p", "po", "pod", "pods":
-		commonOptions.group = subjectGroupPod
-	default:
-		return fmt.Errorf("failed to parse --group: should be one of: all (a), namespace (n), pod (p)")
-	}
-	return nil
+	cmd.Flags().StringVarP(&commonOptions.group, flagGroup, "g", "pod", "experimental: merge entries within each subject group (pod [p], ns [n], all [a])")
 }
 
 func addSelectorOption(cmd *cobra.Command) {
@@ -178,15 +193,12 @@ func parseCIDROptions(ingress, egress bool, prefix string, opts *cidrOptions) (p
 var rootCmd = &cobra.Command{
 	Use: "npv",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := fillRootOptions(cmd); err != nil {
-			return err
-		}
-		fillPolicyOptions()
-		return nil
+		return fillOptions(cmd)
 	},
 }
 
 func Execute() {
+	cobra.EnableTraverseRunHooks = true
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/npv/app/subject.go
+++ b/cmd/npv/app/subject.go
@@ -32,10 +32,6 @@ var subjectCmd = &cobra.Command{
 }
 
 func runSubject(ctx context.Context, stdout io.Writer, name string) error {
-	if err := validateGroupOption(); err != nil {
-		return err
-	}
-
 	clientset, _, err := createK8sClients()
 	if err != nil {
 		return fmt.Errorf("failed to create k8s clients: %w", err)

--- a/pkg/proxy/client.go
+++ b/pkg/proxy/client.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cybozu-go/network-policy-viewer/pkg/gvr"
 )
 
-type ProxyConfig struct {
+type Config struct {
 	Namespace string
 	Selector  string
 	Port      uint16
@@ -43,7 +43,7 @@ type Client struct {
 
 var (
 	ciliumModuleVersion string
-	proxyConfig         *ProxyConfig
+	config              *Config
 
 	proxyMutex          sync.Mutex
 	cachedCiliumClients = make(map[string]*Client)
@@ -66,8 +66,8 @@ func init() {
 	}
 }
 
-func SetProxyConfig(config *ProxyConfig) {
-	proxyConfig = config
+func SetConfig(c *Config) {
+	config = c
 }
 
 func getPodNodeName(ctx context.Context, c *kubernetes.Clientset, namespace, name string) (string, error) {
@@ -84,9 +84,9 @@ func getProxyEndpoint(ctx context.Context, c *kubernetes.Clientset, namespace, n
 		return "", err
 	}
 
-	pods, err := c.CoreV1().Pods(proxyConfig.Namespace).List(ctx, metav1.ListOptions{
+	pods, err := c.CoreV1().Pods(config.Namespace).List(ctx, metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + targetNode,
-		LabelSelector: proxyConfig.Selector,
+		LabelSelector: config.Selector,
 	})
 	if err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func getProxyEndpoint(ctx context.Context, c *kubernetes.Clientset, namespace, n
 	}
 
 	podIP := pods.Items[0].Status.PodIP
-	return fmt.Sprintf("http://%s:%d", podIP, proxyConfig.Port), nil
+	return fmt.Sprintf("http://%s:%d", podIP, config.Port), nil
 }
 
 func getPodEndpointID(ctx context.Context, d *dynamic.DynamicClient, namespace, name string) (int64, error) {


### PR DESCRIPTION
This PR contains the following minor improvements.

### Rename proxy.ProxyConfig to proxy.Config

This commit removes redundant variables and keywords.

### Handle group option in PersistentPreRunE

This commit validates the input of the group option (`--group`) on `rootCmd`. That was previously done in subcommands.