### PR TITLE
Fix missing subject in --group=ns output when --namespace-selector is set

### DIFF
--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -61,6 +61,10 @@ func SetSelectorConfig(c *SelectorConfig) {
 	selectorConfig = c
 }
 
+func IsMultiNamespace() bool {
+	return selectorConfig.AllNamespaces || selectorConfig.NamespaceSelector != ""
+}
+
 func GetNamespaceListOptions() metav1.ListOptions {
 	switch {
 	case selectorConfig.AllNamespaces:
@@ -96,7 +100,7 @@ func ShouldPrintSubject(podName string) bool {
 	case GroupAll:
 		return false
 	case GroupNamespace:
-		return selectorConfig.AllNamespaces
+		return IsMultiNamespace()
 	case GroupPod:
 		return podName == ""
 	default:
@@ -111,7 +115,7 @@ func GetPodSubject(namespace, name string) string {
 	case GroupNamespace:
 		return namespace
 	case GroupPod:
-		if selectorConfig.AllNamespaces || selectorConfig.NamespaceSelector != "" {
+		if IsMultiNamespace() {
 			return namespace + "/" + name
 		} else {
 			return name
@@ -123,7 +127,7 @@ func GetPodSubject(namespace, name string) string {
 
 // ListSubjectPods returns the pods that should be examined according to the current options.
 func ListSubjectPods(ctx context.Context, clientset *kubernetes.Clientset, name string) ([]*corev1.Pod, error) {
-	if (name != "") && (selectorConfig.AllNamespaces || selectorConfig.NamespaceSelector != "" || selectorConfig.PodSelector != "") {
+	if (name != "") && (IsMultiNamespace() || selectorConfig.PodSelector != "") {
 		return nil, errors.New("multiple pods should not be selected when pod name is specified")
 	}
 


### PR DESCRIPTION
```
root@ubuntu-75697f7bb7-97bkm:/# npv inspect -N group=test --used -gn -u

Bug: did not appear previously
---------
SUBJECT | POLICY DIRECTION | IDENTITY NAMESPACE EXAMPLE-ENDPOINT                               | PROTOCOL PORT | BYTES REQUESTS AVERAGE
test    | Allow  Egress    | 16777219 -         cidr:1.1.1.1/32                                | UDP      53   |   186        2    93.0
test    | Allow  Egress    | 16777221 -         cidr:8.8.8.8/32                                | UDP      53   |   186        2    93.0
test    | Allow  Egress    | 24101    test-l3   l3-ingress-explicit-allow-all-79f5bd9c87-zzznq | ANY      ANY  |  1.9K       24    80.7
test    | Allow  Egress    | 11027    test-l4   l4-ingress-explicit-allow-tcp-67776dc6db-2t4v8 | TCP      8000 |  1.9K       24    80.7
test-l3 | Allow  Ingress   | 42261    test      self-67c5cdddbd-j8gd4                          | ANY      ANY  |  1.9K       24    80.7
test-l4 | Allow  Ingress   | 42261    test      self-67c5cdddbd-j8gd4                          | TCP      8000 |  1.9K       24    80.7
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
