### PR TITLE
Implement lookup command

### DIFF
--- a/cmd/npv/app/dump.go
+++ b/cmd/npv/app/dump.go
@@ -20,7 +20,7 @@ func init() {
 
 var dumpCmd = &cobra.Command{
 	Use:   "dump",
-	Short: "dump endpoint status",
+	Short: "Dump endpoint status",
 	Long:  `Dump endpoint status`,
 
 	Args: cobra.ExactArgs(1),

--- a/cmd/npv/app/helper.go
+++ b/cmd/npv/app/helper.go
@@ -1,14 +1,8 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"os"
-	"reflect"
-	"slices"
-	"strings"
-	"text/tabwriter"
 
 	"golang.org/x/term"
 )
@@ -40,117 +34,4 @@ func colored(color int, text string) string {
 		return fmt.Sprintf("\x1b[1;%dm"+"%s"+"\x1b[0m", color, text)
 	}
 	return text
-}
-
-// inflateRow expands a single row into multiple rows when some cells contain slices.
-func inflateRow(input []any, repeat []bool) [][]any {
-	// Input:
-	// a | [1, 2] | [100, 200, 300]
-	//
-	// Output:
-	// a | 1 | 100
-	//   | 2 | 200
-	//   |   | 300
-	ncol := len(input)
-	maxHeight := 1
-	height := make([]int, ncol)
-	inflate := make([]bool, ncol)
-	for i := range ncol {
-		if reflect.TypeOf(input[i]).Kind() == reflect.Slice {
-			height[i] = reflect.ValueOf(input[i]).Len()
-			maxHeight = max(maxHeight, height[i])
-			inflate[i] = true
-		}
-	}
-
-	ret := make([][]any, maxHeight)
-	for j := range maxHeight {
-		entry := make([]any, ncol)
-		for i := range ncol {
-			switch {
-			case repeat[i]:
-				fallthrough
-			case (j == 0) && !inflate[i]:
-				entry[i] = input[i]
-			case j < height[i]:
-				v := reflect.ValueOf(input[i]).Index(j).Interface()
-				entry[i] = v
-			default:
-				entry[i] = ""
-			}
-		}
-		ret[j] = entry
-	}
-	return ret
-}
-
-func writeSimpleOrJson(w io.Writer, content any, header []string, count int, values func(index int) []any) error {
-	expr := make([][]any, 0)
-	if rootOptions.output == OutputSimple {
-		repeat := make([]bool, len(header))
-		for i := range len(header) {
-			repeat[i] = header[i] == "|"
-		}
-
-		for i := range count {
-			v := values(i)
-			entries := inflateRow(v, repeat)
-			expr = append(expr, entries...)
-		}
-
-		header = slices.Clone(header)
-		for j := 0; j < len(header); j++ {
-			h := header[j]
-			if strings.HasSuffix(h, ":") {
-				h = h[:len(h)-1]
-				header[j] = h
-				width := len(h)
-				for i := range len(expr) {
-					v := fmt.Sprintf("%v", expr[i][j])
-					width = max(width, len(v))
-					expr[i][j] = v
-				}
-
-				format := fmt.Sprintf("%%%ds", width)
-				header[j] = fmt.Sprintf(format, header[j])
-				for i := range len(expr) {
-					expr[i][j] = fmt.Sprintf(format, expr[i][j])
-				}
-			}
-		}
-	} else {
-		for i := range count {
-			expr = append(expr, values(i))
-		}
-	}
-
-	switch rootOptions.output {
-	case OutputJson:
-		text, err := json.MarshalIndent(content, "", "  ")
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(text)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write([]byte{'\n'})
-		return err
-	case OutputSimple:
-		tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
-		if !rootOptions.noHeaders {
-			if _, err := tw.Write([]byte(strings.Join(header, "\t") + "\n")); err != nil {
-				return err
-			}
-		}
-		for i := range len(expr) {
-			format := strings.Repeat("%v\t", len(header)-1) + "%v\n"
-			if _, err := tw.Write([]byte(fmt.Sprintf(format, expr[i]...))); err != nil {
-				return err
-			}
-		}
-		return tw.Flush()
-	default:
-		return fmt.Errorf("unknown format: %s", rootOptions.output)
-	}
 }

--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/cidr"
 	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
 	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
@@ -263,7 +264,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 	if subject.ShouldPrintSubject(name) {
 		header = append(subHeader, header...)
 	}
-	return writeSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
+	return output.WriteSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		protocol := u8proto.U8proto(p.Protocol).String()
 		var port string
@@ -274,7 +275,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 		}
 		var example any
 		example = p.Example
-		if (rootOptions.output == OutputSimple) && strings.HasPrefix(p.Example, "cidr:") {
+		if (rootOptions.output == output.FormatSimple) && strings.HasPrefix(p.Example, "cidr:") {
 			p.Example = strings.Replace(p.Example, "+", ",    +", -1)
 			p.Example = strings.Replace(p.Example, "-", ",    -", -1)
 			if strings.Contains(p.Example, ",") {

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -12,33 +12,27 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/gvk"
 	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
 	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
-
-var listOptions struct {
-	manifests bool
-}
 
 func init() {
 	addGroupOption(listCmd)
 	addPodSelectorOption(listCmd)
 	addDirectionOption(listCmd)
-	listCmd.Flags().BoolVarP(&listOptions.manifests, "manifests", "m", false, "show policy manifests")
+	addManifestOption(listCmd)
 	rootCmd.AddCommand(listCmd)
 }
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "list network policies applied to a pod",
+	Short: "List network policies applied to a pod",
 	Long:  `List network policies applied to a pod`,
 
 	Args: cobra.RangeArgs(0, 1),
@@ -86,6 +80,9 @@ func parseListEntry(subject, direction string, input []string) listEntry {
 		Subject:   subject,
 		Direction: direction,
 		Namespace: "-",
+	}
+	if commonOptions.manifests {
+		val.Direction = ""
 	}
 	for _, s := range input {
 		switch {
@@ -166,8 +163,25 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		},
 	)
 
-	if listOptions.manifests {
-		return listPolicyManifests(ctx, stdout, c, arr)
+	if commonOptions.manifests {
+		ccnps := make([]*ciliumv2.CiliumClusterwideNetworkPolicy, 0)
+		cnps := make([]*ciliumv2.CiliumNetworkPolicy, 0)
+		for _, p := range arr {
+			if p.Kind == gvk.ClusterwideNetworkPolicy.Kind {
+				var ccnp ciliumv2.CiliumClusterwideNetworkPolicy
+				if err := c.Get(ctx, types.NamespacedName{Name: p.Name}, &ccnp); err != nil {
+					return err
+				}
+				ccnps = append(ccnps, &ccnp)
+			} else {
+				var cnp ciliumv2.CiliumNetworkPolicy
+				if err := c.Get(ctx, types.NamespacedName{Namespace: p.Namespace, Name: p.Name}, &cnp); err != nil {
+					return err
+				}
+				cnps = append(cnps, &cnp)
+			}
+		}
+		return output.WriteManifests(stdout, ccnps, cnps)
 	}
 
 	subHeader := []string{"SUBJECT", "|"}
@@ -175,7 +189,7 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 	if subject.ShouldPrintSubject(name) {
 		header = append(subHeader, header...)
 	}
-	return writeSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
+	return output.WriteSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		subValues := []any{p.Subject, "|"}
 		values := []any{p.Direction, "|", p.Kind, p.Namespace, p.Name}
@@ -184,76 +198,4 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		}
 		return values
 	})
-}
-
-func listPolicyManifests(ctx context.Context, w io.Writer, c client.Client, policyList []listEntry) error {
-	// remove direction info and sort again
-	for i := range policyList {
-		policyList[i].Direction = ""
-	}
-	sort.Slice(policyList, func(i, j int) bool { return compareListEntry(&policyList[i], &policyList[j]) < 0 })
-
-	var previous types.NamespacedName
-	first := true
-	for _, p := range policyList {
-		// a same policy may appear twice from egress and ingress rules, so we need to dedup them
-		next := types.NamespacedName{
-			Namespace: p.Namespace,
-			Name:      p.Name,
-		}
-		if previous == next {
-			continue
-		}
-		previous = next
-
-		if !first {
-			if _, err := fmt.Fprintln(w, "---"); err != nil {
-				return err
-			}
-		}
-		first = false
-
-		isCNP := p.Kind == "CiliumNetworkPolicy"
-		var obj map[string]any
-		var err error
-		if isCNP {
-			var cnp ciliumv2.CiliumNetworkPolicy
-			if err := c.Get(ctx, types.NamespacedName{Namespace: p.Namespace, Name: p.Name}, &cnp); err != nil {
-				return err
-			}
-
-			cnp.SetGroupVersionKind(gvk.NetworkPolicy)
-			obj, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&cnp)
-			if err != nil {
-				return err
-			}
-		} else {
-			var ccnp ciliumv2.CiliumClusterwideNetworkPolicy
-			if err := c.Get(ctx, types.NamespacedName{Name: p.Name}, &ccnp); err != nil {
-				return err
-			}
-
-			ccnp.SetGroupVersionKind(gvk.ClusterwideNetworkPolicy)
-			obj, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ccnp)
-			if err != nil {
-				return err
-			}
-		}
-		unstructured.RemoveNestedField(obj, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
-		unstructured.RemoveNestedField(obj, "metadata", "creationTimestamp")
-		unstructured.RemoveNestedField(obj, "metadata", "generation")
-		unstructured.RemoveNestedField(obj, "metadata", "managedFields")
-		unstructured.RemoveNestedField(obj, "metadata", "resourceVersion")
-		unstructured.RemoveNestedField(obj, "metadata", "uid")
-		unstructured.RemoveNestedField(obj, "status")
-
-		data, err := yaml.Marshal(obj)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, "%s", string(data)); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/cmd/npv/app/lookup.go
+++ b/cmd/npv/app/lookup.go
@@ -162,6 +162,8 @@ func runLookup(ctx context.Context, stdout io.Writer, name string) error {
 	if err := c.List(ctx, &ccnpList); err != nil {
 		return err
 	}
+
+ccnpLoop:
 	for _, ccnp := range ccnpList.Items {
 		rules, err := ccnp.Parse()
 		if err != nil {
@@ -173,6 +175,7 @@ func runLookup(ctx context.Context, stdout io.Writer, name string) error {
 			if commonOptions.manifests {
 				if len(matchIDs) > 0 {
 					ccnps = append(ccnps, &ccnp)
+					continue ccnpLoop
 				}
 			} else {
 				for _, id := range matchIDs {
@@ -194,6 +197,8 @@ func runLookup(ctx context.Context, stdout io.Writer, name string) error {
 	if err := c.List(ctx, &cnpList); err != nil {
 		return err
 	}
+
+cnpLoop:
 	for _, cnp := range cnpList.Items {
 		rules, err := cnp.Parse()
 		if err != nil {
@@ -205,6 +210,7 @@ func runLookup(ctx context.Context, stdout io.Writer, name string) error {
 			if commonOptions.manifests {
 				if len(matchIDs) > 0 {
 					cnps = append(cnps, &cnp)
+					continue cnpLoop
 				}
 			} else {
 				for _, id := range matchIDs {

--- a/cmd/npv/app/lookup.go
+++ b/cmd/npv/app/lookup.go
@@ -1,0 +1,246 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cybozu-go/network-policy-viewer/pkg/gvk"
+	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
+	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
+)
+
+func init() {
+	addGroupOption(lookupCmd)
+	addPodSelectorOption(lookupCmd)
+	addManifestOption(lookupCmd)
+	rootCmd.AddCommand(lookupCmd)
+}
+
+var lookupCmd = &cobra.Command{
+	Use:   "lookup",
+	Short: "Lookup all network policies referencing a pod",
+	Long:  `Lookup all network policies referencing a pod`,
+
+	Args: cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return runLookup(context.Background(), cmd.OutOrStdout(), "")
+		} else {
+			return runLookup(context.Background(), cmd.OutOrStdout(), args[0])
+		}
+	},
+	ValidArgsFunction: completePods,
+}
+
+type lookupEntry struct {
+	Subject   string `json:"subject"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func compareLookupEntry(x, y *lookupEntry) int {
+	ret := strings.Compare(x.Subject, y.Subject)
+	if ret == 0 {
+		ret = strings.Compare(x.Kind, y.Kind)
+	}
+	if ret == 0 {
+		ret = strings.Compare(x.Namespace, y.Namespace)
+	}
+	if ret == 0 {
+		ret = strings.Compare(x.Name, y.Name)
+	}
+	return ret
+}
+
+func mergeLookupEntry(x, y *lookupEntry) *lookupEntry {
+	return x
+}
+
+func groupSubjectByIdentities(ctx context.Context, c client.Client, name string) (map[uint32][]*corev1.Pod, error) {
+	subjects, err := subject.ListSubjectPods(ctx, c, name)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[uint32][]*corev1.Pod)
+	for _, s := range subjects {
+		id, err := getPodIdentity(ctx, c, s.Namespace, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := ret[id]; !ok {
+			ret[id] = make([]*corev1.Pod, 0)
+		}
+		ret[id] = append(ret[id], s)
+	}
+	return ret, nil
+}
+
+func lookupIdentities(rule *api.Rule, targets map[uint32]labels.LabelArray) []uint32 {
+	ret := make([]uint32, 0)
+
+OUTER:
+	for k, v := range targets {
+		if rule.EndpointSelector.Matches(v) {
+			ret = append(ret, k)
+			continue OUTER
+		}
+		for _, r := range rule.Ingress {
+			for _, s := range r.FromEndpoints {
+				if s.Matches(v) {
+					ret = append(ret, k)
+					continue OUTER
+				}
+			}
+		}
+		for _, r := range rule.IngressDeny {
+			for _, s := range r.FromEndpoints {
+				if s.Matches(v) {
+					ret = append(ret, k)
+					continue OUTER
+				}
+			}
+		}
+		for _, r := range rule.Egress {
+			for _, s := range r.ToEndpoints {
+				if s.Matches(v) {
+					ret = append(ret, k)
+					continue OUTER
+				}
+			}
+		}
+		for _, r := range rule.EgressDeny {
+			for _, s := range r.ToEndpoints {
+				if s.Matches(v) {
+					ret = append(ret, k)
+					continue OUTER
+				}
+			}
+		}
+	}
+	return ret
+}
+
+func runLookup(ctx context.Context, stdout io.Writer, name string) error {
+	c, err := k8s.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create k8s clients: %w", err)
+	}
+
+	idMap, err := getIdentityResourceMap(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	subIDs, err := groupSubjectByIdentities(ctx, c, name)
+	if err != nil {
+		return err
+	}
+
+	subIDLabels := make(map[uint32]labels.LabelArray)
+	for id := range subIDs {
+		subIDLabels[id] = labels.Map2Labels(idMap[id].SecurityLabels, labels.LabelSourceK8s).LabelArray()
+	}
+
+	arr := make([]lookupEntry, 0)
+	ccnps := make([]*ciliumv2.CiliumClusterwideNetworkPolicy, 0)
+	cnps := make([]*ciliumv2.CiliumNetworkPolicy, 0)
+
+	var ccnpList ciliumv2.CiliumClusterwideNetworkPolicyList
+	if err := c.List(ctx, &ccnpList); err != nil {
+		return err
+	}
+	for _, ccnp := range ccnpList.Items {
+		rules, err := ccnp.Parse()
+		if err != nil {
+			return err
+		}
+
+		for _, r := range rules {
+			matchIDs := lookupIdentities(r, subIDLabels)
+			if commonOptions.manifests {
+				if len(matchIDs) > 0 {
+					ccnps = append(ccnps, &ccnp)
+				}
+			} else {
+				for _, id := range matchIDs {
+					for _, p := range subIDs[id] {
+						entry := lookupEntry{
+							Subject:   subject.GetPodSubject(p.Namespace, p.Name),
+							Kind:      gvk.ClusterwideNetworkPolicy.Kind,
+							Namespace: "-",
+							Name:      ccnp.Name,
+						}
+						arr = append(arr, entry)
+					}
+				}
+			}
+		}
+	}
+
+	var cnpList ciliumv2.CiliumNetworkPolicyList
+	if err := c.List(ctx, &cnpList); err != nil {
+		return err
+	}
+	for _, cnp := range cnpList.Items {
+		rules, err := cnp.Parse()
+		if err != nil {
+			return err
+		}
+
+		for _, r := range rules {
+			matchIDs := lookupIdentities(r, subIDLabels)
+			if commonOptions.manifests {
+				if len(matchIDs) > 0 {
+					cnps = append(cnps, &cnp)
+				}
+			} else {
+				for _, id := range matchIDs {
+					for _, p := range subIDs[id] {
+						entry := lookupEntry{
+							Subject:   subject.GetPodSubject(p.Namespace, p.Name),
+							Kind:      gvk.NetworkPolicy.Kind,
+							Namespace: cnp.Namespace,
+							Name:      cnp.Name,
+						}
+						arr = append(arr, entry)
+					}
+				}
+			}
+		}
+	}
+
+	sort.Slice(arr, func(i, j int) bool { return compareLookupEntry(&arr[i], &arr[j]) < 0 })
+	arr = compactBy(arr, compareLookupEntry, mergeLookupEntry)
+
+	if commonOptions.manifests {
+		return output.WriteManifests(stdout, ccnps, cnps)
+	}
+
+	subHeader := []string{"SUBJECT", "|"}
+	header := []string{"KIND", "NAMESPACE", "NAME"}
+	if subject.ShouldPrintSubject(name) {
+		header = append(subHeader, header...)
+	}
+	return output.WriteSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
+		p := arr[index]
+		subValues := []any{p.Subject, "|"}
+		values := []any{p.Kind, p.Namespace, p.Name}
+		if subject.ShouldPrintSubject(name) {
+			values = append(subValues, values...)
+		}
+		return values
+	})
+}

--- a/cmd/npv/app/manifest_range.go
+++ b/cmd/npv/app/manifest_range.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 )
 
 var manifestRangeOptions struct {
@@ -107,7 +108,7 @@ func runManifestRange(ctx context.Context, w io.Writer) error {
 		}
 		arr = append(arr, entry)
 	}
-	return writeSimpleOrJson(w, arr, []string{"PART", "NAMESPACE", "NAME"}, len(arr), func(index int) []any {
+	return output.WriteSimpleOrJson(w, arr, []string{"PART", "NAMESPACE", "NAME"}, len(arr), func(index int) []any {
 		ep := arr[index]
 		return []any{ep.Part, ep.Namespace, ep.Name}
 	})

--- a/cmd/npv/app/reach.go
+++ b/cmd/npv/app/reach.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
 )
 
@@ -161,7 +162,7 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 	}
 
 	header := []string{"ROLE", "DIRECTION", "POLICY", "|", "IDENTITY", "NAMESPACE", "EXAMPLE-ENDPOINT", "|", "PROTOCOL", "PORT", "|", "BYTES:", "REQUESTS:", "AVERAGE:"}
-	return writeSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
+	return output.WriteSimpleOrJson(stdout, arr, header, len(arr), func(index int) []any {
 		p := arr[index]
 		protocol := u8proto.U8proto(p.Protocol).String()
 		var port string
@@ -172,7 +173,7 @@ func runReach(ctx context.Context, stdout, stderr io.Writer) error {
 		}
 		var example any
 		example = p.Example
-		if (rootOptions.output == OutputSimple) && strings.HasPrefix(p.Example, "cidr:") {
+		if (rootOptions.output == output.FormatSimple) && strings.HasPrefix(p.Example, "cidr:") {
 			p.Example = strings.Replace(p.Example, "+", ",    +", -1)
 			p.Example = strings.Replace(p.Example, "-", ",    -", -1)
 			if strings.Contains(p.Example, ",") {

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -10,13 +10,9 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/cidr"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
 	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
-)
-
-const (
-	OutputJson   = "json"
-	OutputSimple = "simple"
 )
 
 const (
@@ -44,8 +40,12 @@ var rootOptions struct {
 }
 
 func fillRootOptions() error {
-	rootOptions.output = viper.GetString(flagOutput)
-	rootOptions.noHeaders = viper.GetBool(flagNoHeaders)
+	oc := output.Config{
+		Format:    viper.GetString(flagOutput),
+		NoHeaders: viper.GetBool(flagNoHeaders),
+	}
+	output.SetConfig(&oc)
+
 	rootOptions.units = viper.GetBool(flagUnits)
 	rootOptions.jobs = viper.GetInt(flagJobs)
 
@@ -62,6 +62,9 @@ func fillGroupOptions(cmd *cobra.Command) error {
 		group, err := cmd.Flags().GetString(flagGroup)
 		if err != nil {
 			return err
+		}
+		if commonOptions.manifests {
+			group = subject.GroupAll
 		}
 		if err := subject.SetGroup(group); err != nil {
 			return err
@@ -151,7 +154,8 @@ func fillSelectorOptions(cmd *cobra.Command) error {
 }
 
 var commonOptions struct {
-	with cidrOptions
+	with      cidrOptions
+	manifests bool
 }
 
 var policyOptions struct {
@@ -184,7 +188,7 @@ func init() {
 	rootCmd.PersistentFlags().String(flagProxyNamespace, "cilium-agent-proxy", "namespace of the proxy pods")
 	rootCmd.PersistentFlags().String(flagProxySelector, "app.kubernetes.io/name=cilium-agent-proxy", "label selector to find the proxy pods")
 	rootCmd.PersistentFlags().Uint16(flagProxyPort, 8080, "port number of the proxy endpoints")
-	rootCmd.PersistentFlags().StringP(flagOutput, "o", OutputSimple, "output format")
+	rootCmd.PersistentFlags().StringP(flagOutput, "o", output.FormatSimple, "output format")
 	rootCmd.PersistentFlags().Bool(flagNoHeaders, false, "stop printing header")
 	rootCmd.PersistentFlags().BoolP(flagUnits, "u", false, "use human-readable units (power of 1024) for traffic volume")
 	rootCmd.PersistentFlags().IntP(flagJobs, "j", 4, "number of parallel queries")
@@ -261,6 +265,10 @@ func parseCIDROptions(ingress, egress bool, prefix string, opts *cidrOptions) (p
 	default:
 		return nil, fmt.Errorf("one of --%s-cidrs, --%s-private-cidrs, --%s-public-cidrs can be specified", prefix, prefix, prefix)
 	}
+}
+
+func addManifestOption(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&commonOptions.manifests, "manifests", "m", false, "show policy manifests")
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/npv/app/subject.go
+++ b/cmd/npv/app/subject.go
@@ -20,7 +20,7 @@ func init() {
 
 var subjectCmd = &cobra.Command{
 	Use:   "subject",
-	Short: "list subjects with current selector and group options",
+	Short: "List subjects with current selector and group options",
 	Long:  `List subjects with current selector and group options`,
 
 	Args: cobra.RangeArgs(0, 1),

--- a/cmd/npv/app/summary.go
+++ b/cmd/npv/app/summary.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cybozu-go/network-policy-viewer/pkg/k8s"
+	"github.com/cybozu-go/network-policy-viewer/pkg/output"
 	"github.com/cybozu-go/network-policy-viewer/pkg/proxy"
 	"github.com/cybozu-go/network-policy-viewer/pkg/subject"
 )
@@ -117,7 +118,7 @@ func runSummary(ctx context.Context, stdout, stderr io.Writer, name string) erro
 	sort.Slice(summary, func(i, j int) bool { return lessSummaryEntry(&summary[i], &summary[j]) })
 
 	header := []string{"NAMESPACE", "NAME", "INGRESS-ALLOW", "INGRESS-DENY", "EGRESS-ALLOW", "EGRESS-DENY"}
-	return writeSimpleOrJson(stdout, summary, header, len(summary), func(index int) []any {
+	return output.WriteSimpleOrJson(stdout, summary, header, len(summary), func(index int) []any {
 		p := summary[index]
 		return []any{p.Namespace, p.Name, p.IngressAllow, p.IngressDeny, p.EgressAllow, p.EgressDeny}
 	})

--- a/e2e/lookup_test.go
+++ b/e2e/lookup_test.go
@@ -1,0 +1,218 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func testLookup() {
+	cases := []struct {
+		Namespace string
+		Selector  string
+		Expected  string
+	}{
+		{
+			Namespace: "test",
+			Selector:  "test=self",
+			Expected: `self,CiliumClusterwideNetworkPolicy,-,l3-baseline
+self,CiliumNetworkPolicy,test,l3-self
+self,CiliumNetworkPolicy,test,l4-self
+self,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-allow-all
+self,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-deny-all
+self,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-allow-any
+self,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-allow-tcp
+self,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-deny-any
+self,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-deny-udp`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-allow-all",
+			Expected: `l3-ingress-explicit-allow-all,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-allow-all,CiliumNetworkPolicy,test,l3-self
+l3-ingress-explicit-allow-all,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-allow-all`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-implicit-deny-all",
+			Expected: `l3-ingress-implicit-deny-all,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-implicit-deny-all,CiliumNetworkPolicy,test,l3-self`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-deny-all",
+			Expected: `l3-ingress-explicit-deny-all,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-ingress-explicit-deny-all,CiliumNetworkPolicy,test,l3-self
+l3-ingress-explicit-deny-all,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-deny-all`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-egress-implicit-deny-all",
+			Expected:  `l3-egress-implicit-deny-all,CiliumClusterwideNetworkPolicy,-,l3-baseline`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-egress-explicit-deny-all",
+			Expected: `l3-egress-explicit-deny-all,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l3-egress-explicit-deny-all,CiliumNetworkPolicy,test,l3-self`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-ingress-explicit-allow-any",
+			Expected: `l4-ingress-explicit-allow-any,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-ingress-explicit-allow-any,CiliumNetworkPolicy,test,l4-self
+l4-ingress-explicit-allow-any,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-allow-any`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-ingress-explicit-allow-tcp",
+			Expected: `l4-ingress-explicit-allow-tcp,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-ingress-explicit-allow-tcp,CiliumNetworkPolicy,test,l4-self
+l4-ingress-explicit-allow-tcp,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-allow-tcp`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-ingress-explicit-deny-any",
+			Expected: `l4-ingress-explicit-deny-any,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-ingress-explicit-deny-any,CiliumNetworkPolicy,test,l4-self
+l4-ingress-explicit-deny-any,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-deny-any`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-ingress-explicit-deny-udp",
+			Expected: `l4-ingress-explicit-deny-udp,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-ingress-explicit-deny-udp,CiliumNetworkPolicy,test,l4-self
+l4-ingress-explicit-deny-udp,CiliumNetworkPolicy,test-l4,l4-ingress-explicit-deny-udp`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-egress-explicit-deny-any",
+			Expected: `l4-egress-explicit-deny-any,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-egress-explicit-deny-any,CiliumNetworkPolicy,test,l4-self`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-egress-explicit-deny-tcp",
+			Expected: `l4-egress-explicit-deny-tcp,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-egress-explicit-deny-tcp,CiliumNetworkPolicy,test,l4-self`,
+		},
+		{
+			Namespace: "test-l4",
+			Selector:  "test=l4-ingress-all-allow-tcp",
+			Expected: `l4-ingress-all-allow-tcp,CiliumClusterwideNetworkPolicy,-,l3-baseline
+l4-ingress-all-allow-tcp,CiliumNetworkPolicy,test-l4,l4-ingress-all-allow-tcp`,
+		},
+	}
+
+	It("should lookup network policies applied to the pods", func() {
+		for _, c := range cases {
+			By(fmt.Sprintf("checking %v %v", c.Namespace, c.Selector))
+			podName := onePodByLabelSelector(Default, c.Namespace, c.Selector)
+			args := []string{"lookup", "-o=json", "-n=" + c.Namespace, podName}
+			result := runViewerSafe(Default, nil, args...)
+			result = fixJsonPodField(Default, result, "subject")
+			result = jqSafe(Default, result, "-r", ".[] | [.subject, .kind, .namespace, .name] | @csv")
+			resultString := strings.Replace(string(result), `"`, "", -1)
+			Expect(resultString).To(Equal(c.Expected), "compare failed. actual: %s\nexpected: %s", resultString, c.Expected)
+		}
+	})
+}
+
+func testLookupManifests() {
+	expected := `apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  annotations: {}
+  name: l3-baseline
+spec:
+  egressDeny:
+  - toEndpoints:
+    - matchLabels:
+        k8s:test: scapegoat
+  enableDefaultDeny:
+    egress: true
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      k8s:group: test
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:test: scapegoat
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations: {}
+  name: l3-ingress-explicit-allow-all
+  namespace: test-l3
+spec:
+  enableDefaultDeny:
+    egress: false
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      k8s:test: l3-ingress-explicit-allow-all
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test
+        k8s:test: self
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations: {}
+  name: l3-self
+  namespace: test
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test-l3
+        k8s:test: l3-ingress-explicit-allow-all
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test-l3
+        k8s:test: l3-ingress-no-rule
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test-l3
+        k8s:test: l3-ingress-implicit-deny-all
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test-l3
+        k8s:test: l3-ingress-explicit-deny-all
+  - toCIDRSet:
+    - cidrGroupSelector:
+        matchLabels:
+          group: test-group
+  egressDeny:
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name: test-l3
+        k8s:test: l3-egress-explicit-deny-all
+  enableDefaultDeny:
+    egress: true
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      k8s:test: self
+  ingress:
+  - fromCIDR:
+    - 10.100.0.0/16
+    - 172.0.0.0/8
+  - fromCIDRSet:
+    - cidr: 10.120.0.0/16
+      except:
+      - 10.120.0.0/24
+    - cidrGroupRef: cidr-group-1`
+
+	It("should lookup referencing policy manifests", func() {
+		podName := onePodByLabelSelector(Default, "test-l3", "test=l3-ingress-explicit-allow-all")
+		result := strings.TrimSpace(string(runViewerSafe(Default, nil, "lookup", "-n=test-l3", "-m", podName)))
+		Expect(result).To(Equal(expected), "compare failed.\nactual: %s\nexpected: %s", result, expected)
+	})
+}

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -54,6 +54,8 @@ func runTest() {
 	Context("list", testList)
 	Context("list-with-selector", testListWithSelector)
 	Context("list-manifests", testListManifests)
+	Context("lookup", testLookup)
+	Context("lookup-manifests", testLookupManifests)
 	Context("id-tree", testIdTree)
 	Context("inspect", testInspect)
 	Context("summary", testSummary)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.41.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	go.yaml.in/yaml/v2 v2.4.4
 	golang.org/x/mod v0.37.0
 	golang.org/x/term v0.44.0
 	k8s.io/api v0.35.5
@@ -104,7 +105,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.uber.org/dig v1.17.1 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect

--- a/pkg/output/policy.go
+++ b/pkg/output/policy.go
@@ -1,0 +1,77 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"go.yaml.in/yaml/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cybozu-go/network-policy-viewer/pkg/gvk"
+)
+
+func cleanFields(obj map[string]any) {
+	unstructured.RemoveNestedField(obj, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration")
+	unstructured.RemoveNestedField(obj, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(obj, "metadata", "generation")
+	unstructured.RemoveNestedField(obj, "metadata", "managedFields")
+	unstructured.RemoveNestedField(obj, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(obj, "metadata", "uid")
+	unstructured.RemoveNestedField(obj, "status")
+}
+
+func WriteManifests(w io.Writer, ccnps []*ciliumv2.CiliumClusterwideNetworkPolicy, cnps []*ciliumv2.CiliumNetworkPolicy) error {
+	first := true
+	for _, ccnp := range ccnps {
+		if !first {
+			if _, err := fmt.Fprintln(w, "---"); err != nil {
+				return err
+			}
+		}
+		first = false
+
+		ccnp = ccnp.DeepCopy()
+		ccnp.SetGroupVersionKind(gvk.ClusterwideNetworkPolicy)
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ccnp)
+		if err != nil {
+			return err
+		}
+		cleanFields(obj)
+
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s", string(data)); err != nil {
+			return err
+		}
+	}
+
+	for _, cnp := range cnps {
+		if !first {
+			if _, err := fmt.Fprintln(w, "---"); err != nil {
+				return err
+			}
+		}
+		first = false
+
+		cnp = cnp.DeepCopy()
+		cnp.SetGroupVersionKind(gvk.NetworkPolicy)
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&cnp)
+		if err != nil {
+			return err
+		}
+		cleanFields(obj)
+
+		data, err := yaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s", string(data)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/output/simple.go
+++ b/pkg/output/simple.go
@@ -1,0 +1,146 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"strings"
+	"text/tabwriter"
+)
+
+const (
+	FormatJson   = "json"
+	FormatSimple = "simple"
+)
+
+type Config struct {
+	Format    string
+	NoHeaders bool
+}
+
+var (
+	config *Config
+)
+
+func GetConfig() *Config {
+	return config
+}
+
+func SetConfig(c *Config) {
+	config = c
+}
+
+// inflateRow expands a single row into multiple rows when some cells contain slices.
+func inflateRow(input []any, repeat []bool) [][]any {
+	// Input:
+	// a | [1, 2] | [100, 200, 300]
+	//
+	// Output:
+	// a | 1 | 100
+	//   | 2 | 200
+	//   |   | 300
+	ncol := len(input)
+	maxHeight := 1
+	height := make([]int, ncol)
+	inflate := make([]bool, ncol)
+	for i := range ncol {
+		if reflect.TypeOf(input[i]).Kind() == reflect.Slice {
+			height[i] = reflect.ValueOf(input[i]).Len()
+			maxHeight = max(maxHeight, height[i])
+			inflate[i] = true
+		}
+	}
+
+	ret := make([][]any, maxHeight)
+	for j := range maxHeight {
+		entry := make([]any, ncol)
+		for i := range ncol {
+			switch {
+			case repeat[i]:
+				fallthrough
+			case (j == 0) && !inflate[i]:
+				entry[i] = input[i]
+			case j < height[i]:
+				v := reflect.ValueOf(input[i]).Index(j).Interface()
+				entry[i] = v
+			default:
+				entry[i] = ""
+			}
+		}
+		ret[j] = entry
+	}
+	return ret
+}
+
+func WriteSimpleOrJson(w io.Writer, content any, header []string, count int, values func(index int) []any) error {
+	expr := make([][]any, 0)
+	if config.Format == FormatSimple {
+		repeat := make([]bool, len(header))
+		for i := range len(header) {
+			repeat[i] = header[i] == "|"
+		}
+
+		for i := range count {
+			v := values(i)
+			entries := inflateRow(v, repeat)
+			expr = append(expr, entries...)
+		}
+
+		header = slices.Clone(header)
+		for j := 0; j < len(header); j++ {
+			h := header[j]
+			if strings.HasSuffix(h, ":") {
+				h = h[:len(h)-1]
+				header[j] = h
+				width := len(h)
+				for i := range len(expr) {
+					v := fmt.Sprintf("%v", expr[i][j])
+					width = max(width, len(v))
+					expr[i][j] = v
+				}
+
+				format := fmt.Sprintf("%%%ds", width)
+				header[j] = fmt.Sprintf(format, header[j])
+				for i := range len(expr) {
+					expr[i][j] = fmt.Sprintf(format, expr[i][j])
+				}
+			}
+		}
+	} else {
+		for i := range count {
+			expr = append(expr, values(i))
+		}
+	}
+
+	switch config.Format {
+	case FormatJson:
+		text, err := json.MarshalIndent(content, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(text)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write([]byte{'\n'})
+		return err
+	case FormatSimple:
+		tw := tabwriter.NewWriter(w, 0, 1, 1, ' ', 0)
+		if !config.NoHeaders {
+			if _, err := tw.Write([]byte(strings.Join(header, "\t") + "\n")); err != nil {
+				return err
+			}
+		}
+		for i := range len(expr) {
+			format := strings.Repeat("%v\t", len(header)-1) + "%v\n"
+			if _, err := tw.Write([]byte(fmt.Sprintf(format, expr[i]...))); err != nil {
+				return err
+			}
+		}
+		return tw.Flush()
+	default:
+		return fmt.Errorf("unknown format: %s", config.Format)
+	}
+}


### PR DESCRIPTION
This PR implements `npv lookup`, that displays all the CCNP/CNPs that reference selected pods.
The command is beneficial when we want to check we can safely update some pods' security labels.

```
# List all the CCNP/CNPs that reference test/self-67c5cdddbd-9pjcf
root@ubuntu-75697f7bb7-sczcz:/# npv lookup -n test self-67c5cdddbd-9pjcf
KIND                           NAMESPACE NAME
CiliumClusterwideNetworkPolicy -         l3-baseline
CiliumNetworkPolicy            test      l3-self
CiliumNetworkPolicy            test      l4-self
CiliumNetworkPolicy            test-l3   l3-ingress-explicit-allow-all
CiliumNetworkPolicy            test-l3   l3-ingress-explicit-deny-all
CiliumNetworkPolicy            test-l4   l4-ingress-explicit-allow-any
CiliumNetworkPolicy            test-l4   l4-ingress-explicit-allow-tcp
CiliumNetworkPolicy            test-l4   l4-ingress-explicit-deny-any
CiliumNetworkPolicy            test-l4   l4-ingress-explicit-deny-udp

# List all the CCNP/CNPs that reference at least one pod in the test-l3 namespace
root@ubuntu-75697f7bb7-sczcz:/# npv lookup -n test-l3 -ga
KIND                           NAMESPACE NAME
CiliumClusterwideNetworkPolicy -         l3-baseline
CiliumNetworkPolicy            test      l3-self
CiliumNetworkPolicy            test-l3   l3-ingress-explicit-allow-all
CiliumNetworkPolicy            test-l3   l3-ingress-explicit-deny-all
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
