### PR TITLE
Add --allowed and --denied options to list command

### DIFF
--- a/cmd/npv/app/inspect.go
+++ b/cmd/npv/app/inspect.go
@@ -29,8 +29,6 @@ var inspectOptions struct {
 }
 
 func init() {
-	inspectCmd.Flags().BoolVar(&inspectOptions.allowed, "allowed", false, "show allowed-rules only")
-	inspectCmd.Flags().BoolVar(&inspectOptions.denied, "denied", false, "show denied-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.used, "used", false, "show used-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.unused, "unused", false, "show unused-rules only")
 	inspectCmd.Flags().BoolVar(&inspectOptions.maskCIDRs, "mask-cidrs", false, "mask cluster-external CIDRs and unify them into public, private, and unknown")
@@ -38,6 +36,7 @@ func init() {
 	addPodSelectorOption(inspectCmd)
 	addWithCIDROptions(inspectCmd)
 	addDirectionOption(inspectCmd)
+	addAllowDenyOption(inspectCmd)
 	rootCmd.AddCommand(inspectCmd)
 }
 
@@ -117,10 +116,6 @@ func mergeInspectEntry(x, y *inspectEntry) *inspectEntry {
 }
 
 func parseInspectOptions() {
-	if !inspectOptions.allowed && !inspectOptions.denied {
-		inspectOptions.allowed = true
-		inspectOptions.denied = true
-	}
 	if !inspectOptions.used && !inspectOptions.unused {
 		inspectOptions.used = true
 		inspectOptions.unused = true
@@ -223,7 +218,7 @@ func runInspect(ctx context.Context, stdout, stderr io.Writer, name string) erro
 	parseInspectOptions()
 	basicFilter := proxy.MakeBasicFilter(
 		policyOptions.ingress, policyOptions.egress,
-		inspectOptions.allowed, inspectOptions.denied,
+		policyOptions.allowed, policyOptions.denied,
 		inspectOptions.used, inspectOptions.unused,
 	)
 	withFilter, err := parseCIDROptions(true, true, "with", &commonOptions.with)

--- a/cmd/npv/app/list.go
+++ b/cmd/npv/app/list.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,6 +27,7 @@ func init() {
 	addGroupOption(listCmd)
 	addPodSelectorOption(listCmd)
 	addDirectionOption(listCmd)
+	addAllowDenyOption(listCmd)
 	addManifestOption(listCmd)
 	rootCmd.AddCommand(listCmd)
 }
@@ -97,6 +99,14 @@ func parseListEntry(subject, direction string, input []string) listEntry {
 	return val
 }
 
+func hasAllowRule(rule *api.Rule) bool {
+	return len(rule.Ingress)+len(rule.Egress) > 0
+}
+
+func hasDenyRule(rule *api.Rule) bool {
+	return len(rule.IngressDeny)+len(rule.EgressDeny) > 0
+}
+
 func runListOnPod(ctx context.Context, stderr io.Writer, c client.Client, pod *corev1.Pod) ([]listEntry, error) {
 	policySet := make(map[listEntry]any)
 
@@ -145,7 +155,6 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		return err
 	}
 
-	// The same rule appears multiple times in the response, so we need to dedup it
 	arr := mapNodeReduce(pods,
 		func() []listEntry {
 			return make([]listEntry, 0)
@@ -163,25 +172,64 @@ func runList(ctx context.Context, stdout, stderr io.Writer, name string) error {
 		},
 	)
 
-	if commonOptions.manifests {
-		ccnps := make([]*ciliumv2.CiliumClusterwideNetworkPolicy, 0)
-		cnps := make([]*ciliumv2.CiliumNetworkPolicy, 0)
-		for _, p := range arr {
-			if p.Kind == gvk.ClusterwideNetworkPolicy.Kind {
-				var ccnp ciliumv2.CiliumClusterwideNetworkPolicy
-				if err := c.Get(ctx, types.NamespacedName{Name: p.Name}, &ccnp); err != nil {
-					return err
-				}
-				ccnps = append(ccnps, &ccnp)
-			} else {
-				var cnp ciliumv2.CiliumNetworkPolicy
-				if err := c.Get(ctx, types.NamespacedName{Namespace: p.Namespace, Name: p.Name}, &cnp); err != nil {
-					return err
-				}
-				cnps = append(cnps, &cnp)
+	ccnps := make(map[types.NamespacedName]*ciliumv2.CiliumClusterwideNetworkPolicy)
+	cnps := make(map[types.NamespacedName]*ciliumv2.CiliumNetworkPolicy)
+	for _, l := range arr {
+		if l.Kind == gvk.ClusterwideNetworkPolicy.Kind {
+			var ccnp ciliumv2.CiliumClusterwideNetworkPolicy
+			if err := c.Get(ctx, types.NamespacedName{Name: l.Name}, &ccnp); err != nil {
+				return err
 			}
+
+			allowMatch := policyOptions.allowed && (hasAllowRule(ccnp.Spec) || slices.ContainsFunc(ccnp.Specs, hasAllowRule))
+			denyMatch := policyOptions.denied && (hasDenyRule(ccnp.Spec) || slices.ContainsFunc(ccnp.Specs, hasDenyRule))
+			if !allowMatch && !denyMatch {
+				continue
+			}
+
+			ccnps[types.NamespacedName{Name: ccnp.Name}] = &ccnp
+		} else {
+			var cnp ciliumv2.CiliumNetworkPolicy
+			if err := c.Get(ctx, types.NamespacedName{Namespace: l.Namespace, Name: l.Name}, &cnp); err != nil {
+				return err
+			}
+
+			allowMatch := policyOptions.allowed && (hasAllowRule(cnp.Spec) || slices.ContainsFunc(cnp.Specs, hasAllowRule))
+			denyMatch := policyOptions.denied && (hasDenyRule(cnp.Spec) || slices.ContainsFunc(cnp.Specs, hasDenyRule))
+			if !allowMatch && !denyMatch {
+				continue
+			}
+
+			cnps[types.NamespacedName{Namespace: cnp.Namespace, Name: cnp.Name}] = &cnp
 		}
-		return output.WriteManifests(stdout, ccnps, cnps)
+	}
+
+	arr = slices.DeleteFunc(arr, func(l listEntry) bool {
+		switch l.Kind {
+		case gvk.ClusterwideNetworkPolicy.Kind:
+			_, ok := ccnps[types.NamespacedName{Name: l.Name}]
+			return !ok
+		default:
+			_, ok := cnps[types.NamespacedName{Namespace: l.Namespace, Name: l.Name}]
+			return !ok
+		}
+	})
+
+	if commonOptions.manifests {
+		ccnpList := slices.Collect(maps.Values(ccnps))
+		cnpList := slices.Collect(maps.Values(cnps))
+
+		slices.SortFunc(ccnpList, func(x, y *ciliumv2.CiliumClusterwideNetworkPolicy) int {
+			return strings.Compare(x.Name, y.Name)
+		})
+		slices.SortFunc(cnpList, func(x, y *ciliumv2.CiliumNetworkPolicy) int {
+			ret := strings.Compare(x.Namespace, y.Namespace)
+			if ret == 0 {
+				ret = strings.Compare(x.Name, y.Name)
+			}
+			return ret
+		})
+		return output.WriteManifests(stdout, ccnpList, cnpList)
 	}
 
 	subHeader := []string{"SUBJECT", "|"}

--- a/cmd/npv/app/root.go
+++ b/cmd/npv/app/root.go
@@ -168,12 +168,18 @@ var commonOptions struct {
 var policyOptions struct {
 	ingress bool
 	egress  bool
+	allowed bool
+	denied  bool
 }
 
 func fillPolicyOptions() {
 	if !policyOptions.ingress && !policyOptions.egress {
 		policyOptions.ingress = true
 		policyOptions.egress = true
+	}
+	if !policyOptions.allowed && !policyOptions.denied {
+		policyOptions.allowed = true
+		policyOptions.denied = true
 	}
 }
 
@@ -247,6 +253,11 @@ func addPodSelectorOption(cmd *cobra.Command) {
 func addDirectionOption(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&policyOptions.ingress, "ingress", false, "show ingress-rules only")
 	cmd.Flags().BoolVar(&policyOptions.egress, "egress", false, "show egress-rules only")
+}
+
+func addAllowDenyOption(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&policyOptions.allowed, "allowed", false, "show allow-rules only")
+	cmd.Flags().BoolVar(&policyOptions.denied, "denied", false, "show deny-rules only")
 }
 
 func addWithCIDROptions(cmd *cobra.Command) {

--- a/e2e/list_test.go
+++ b/e2e/list_test.go
@@ -122,6 +122,32 @@ Ingress,CiliumNetworkPolicy,test,l4-self`,
 Egress,CiliumNetworkPolicy,test,l3-self
 Egress,CiliumNetworkPolicy,test,l4-self`,
 		},
+		// npv list should handle --allowed and --denied
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-allow-all",
+			ExtraArgs: []string{"--ingress", "--allowed"},
+			Expected:  `Ingress,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-allow-all`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-allow-all",
+			ExtraArgs: []string{"--ingress", "--denied"},
+			Expected:  `Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline`,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-deny-all",
+			ExtraArgs: []string{"--ingress", "--allowed"},
+			Expected:  ``,
+		},
+		{
+			Namespace: "test-l3",
+			Selector:  "test=l3-ingress-explicit-deny-all",
+			ExtraArgs: []string{"--ingress", "--denied"},
+			Expected: `Ingress,CiliumClusterwideNetworkPolicy,-,l3-baseline
+Ingress,CiliumNetworkPolicy,test-l3,l3-ingress-explicit-deny-all`,
+		},
 	}
 
 	It("should list applied policies", func() {


### PR DESCRIPTION
This PR adds `--allowed` and `--denied` options to `npv list`.

```
root@ubuntu-69765bcd8-5nzg6:/# npv list -n test-l3 -l test=l3-ingress-explicit-allow-all -ga --allowed
DIRECTION | KIND                NAMESPACE NAME
Ingress   | CiliumNetworkPolicy test-l3   l3-ingress-explicit-allow-all

root@ubuntu-69765bcd8-5nzg6:/# npv list -n test-l3 -l test=l3-ingress-explicit-allow-all -ga --denied 
DIRECTION | KIND                           NAMESPACE NAME
Egress    | CiliumClusterwideNetworkPolicy -         l3-baseline
Ingress   | CiliumClusterwideNetworkPolicy -         l3-baseline
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
